### PR TITLE
[discuss] Switch to superagent instead of raw http.request

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,4 @@
 {
+  "parser": "babel-eslint",
   "extends": "standard"
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "merge-stream": "^1.0.0",
     "multiaddr": "^1.0.0",
     "multipart-stream": "^2.0.0",
+    "request": "^2.65.0",
     "vinyl": "^0.5.1",
     "vinyl-fs-browser": "^2.1.1-1",
     "vinyl-multipart-stream": "^1.2.6"
@@ -25,7 +26,7 @@
     "url": "https://github.com/ipfs/js-ipfs-api"
   },
   "devDependencies": {
-    "brfs": "^1.4.1",
+    "babel-eslint": "^4.1.3",
     "browserify": "^11.0.0",
     "concurrently": "^0.1.1",
     "eslint-config-standard": "^4.4.0",

--- a/src/get-files-stream.js
+++ b/src/get-files-stream.js
@@ -8,7 +8,6 @@ exports = module.exports = getFilesStream
 
 function getFilesStream (files, opts) {
   if (!files) return null
-  if (!Array.isArray(files)) files = [files]
 
   // merge all inputs into one stream
   var adder = new Merge()
@@ -31,7 +30,7 @@ function getFilesStream (files, opts) {
       adder.add(vinylfs.src(file, srcOpts))
 
       // if recursive, glob the contents
-      if (opts.r || opts.recursive) {
+      if (opts.recursive) {
         adder.add(vinylfs.src(file + '/**/*', srcOpts))
       }
     } else {

--- a/test/tests.js
+++ b/test/tests.js
@@ -130,18 +130,19 @@ describe('IPFS Node.js API wrapper tests', function () {
     })
 
     it('add a nested dir', function (done) {
-      if (!isNode) {
-        return done()
-      }
       this.timeout(10000)
 
       apiClients['a'].add(__dirname + '/test-folder', { recursive: true }, function (err, res) {
-        if (err) {
-          throw err
+        if (isNode) {
+          if (err) throw err
+
+          var added = res[res.length - 1]
+          assert.equal(added.Hash, 'QmZdsefMGMeG6bL719gX44XSVQrL6psEgRZdw1SGadFaK2')
+          done()
+        } else {
+          assert.equal(err.message, 'Recursive uploads are not supported in the browser')
+          done()
         }
-        var added = res[res.length - 1]
-        assert.equal(added.Hash, 'QmZdsefMGMeG6bL719gX44XSVQrL6psEgRZdw1SGadFaK2')
-        done()
       })
     })
   })


### PR DESCRIPTION
So I have gotten superagent to work finally. But I sadly can not suggest to merge this. The reason being that the superagent browser part is much worse than the node part. 
My general feeling is still that we should not use `http.request` directly but rather do some research into what request modules are out there and do a good job of what we need them to do in the browser as well as in node. 