### PR TITLE
test: check + print version

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -286,6 +286,8 @@ describe('IPFS Node.js API wrapper tests', function () {
           throw err
         }
         assert(res)
+        assert(res.Version)
+        console.log('      - running against version', res.Version)
         done()
       })
     })


### PR DESCRIPTION
this PR adds a quick check on the version output and prints out the version number (to show what version we're testing against. useful to test new versions)