### PR TITLE
.cat is not returning a stream anymore

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -156,23 +156,21 @@ describe('IPFS Node.js API wrapper tests', function () {
           throw err
         }
 
-        if (isNode) {
-          var buf = ''
-          res
-            .on('error', function (err) { throw err })
-            .on('data', function (data) { buf += data })
-            .on('end', function () {
-              assert.equal(buf, testfile)
-              done()
-            })
-        } else {
-          if (typeof res === 'string') {
-            // Just  a string
-            assert.equal(res, testfile)
-            done()
-            return
-          }
+        if (typeof res === 'string') {
+          // Just  a string
+          assert.equal(res, testfile)
+          done()
+          return
         }
+
+        var buf = ''
+        res
+          .on('error', function (err) { throw err })
+          .on('data', function (data) { buf += data })
+          .on('end', function () {
+            assert.equal(buf, testfile)
+            done()
+          })
       })
     })
   })

--- a/test/tests.js
+++ b/test/tests.js
@@ -152,23 +152,27 @@ describe('IPFS Node.js API wrapper tests', function () {
       this.timeout(10000)
 
       apiClients['a'].cat('Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP', function (err, res) {
-        if (err) throw err
-
-        if (typeof res === 'string') {
-          // Just  a string
-          assert.equal(res, testfile)
-          done()
-          return
+        if (err) {
+          throw err
         }
 
-        var buf = ''
-        res
-          .on('error', function (err) { throw err })
-          .on('data', function (data) { buf += data })
-          .on('end', function () {
-            assert.equal(buf, testfile)
+        if (isNode) {
+          var buf = ''
+          res
+            .on('error', function (err) { throw err })
+            .on('data', function (data) { buf += data })
+            .on('end', function () {
+              assert.equal(buf, testfile)
+              done()
+            })
+        } else {
+          if (typeof res === 'string') {
+            // Just  a string
+            assert.equal(res, testfile)
             done()
-          })
+            return
+          }
+        }
       })
     })
   })


### PR DESCRIPTION
https://github.com/ipfs/js-ipfs-api/pull/92 introduced a bug where in Node.js, the result no longer comes as a stream. This happened because the .cat test was not properly differentiating between node and browser execution.

This PR is a WIP, the test is now checking correctly the behaviour.