### PR TITLE
test under multiple node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
   - "4.0"
+  - '4.2'
+  - '5.0'
+  - stable
 
 before_script:
   - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
-  - "4.0"
-  - '4.2'
-  - '5.0'
+  - '4'
+  - '5'
   - stable
 
 before_script:


### PR DESCRIPTION
I suggest we test under node 4 and 5, and also stable, so when new node versions come out, we would be alerted by a broken build if tests failed there.

Thoughts @diasdavid @Dignifiedquire @VictorBjelkholm?