### PR TITLE
added ipfs.ls test spec

### DIFF
--- a/tasks/daemons.js
+++ b/tasks/daemons.js
@@ -70,11 +70,13 @@ function startDisposableDaemons (callback) {
               throw err
             }
 
-            ipfsNodes[key].startDaemon((err, ignore) => {
+            ipfsNodes[key].startDaemon((err, daemon) => {
               if (err) {
                 throw err
               }
-
+              daemon.add('test/test-folder', {r: true}, (e, r) => {
+                if (e) throw e
+              })
               apiAddrs[key] = ipfsNodes[key].apiAddr
               cb()
             })

--- a/test/api/ls.spec.js
+++ b/test/api/ls.spec.js
@@ -2,18 +2,25 @@
 
 describe('ls', function () {
   it('should correctly retrieve links', function (done) {
-    this.timeout(5000)
     apiClients['a'].ls('QmTDH2RXGn8XyDAo9YyfbZAUXwL1FCr44YJCN9HBZmL9Gj', (err, res) => {
-      if (err) {
-        throw err
-      } else done()
+      if (err === null && res !== undefined) {
+        assert(res.Objects[0].Links[0])
+        done()
+      }
     })
   })
-  it('should correctly throw errors', function (done) {
+  it('should correctly handle a nonexisting hash', function (done) {
     apiClients['a'].ls('surelynotavalidhashheh?', (err, res) => {
-      if (err === undefined) {
-        throw new Error()
-      } else done()
+      if (err !== null && res === undefined) {
+        done()
+      }
+    })
+  })
+  it('should correctly handle a nonexisting path', function (done) {
+    apiClients['a'].ls('QmTDH2RXGn8XyDAo9YyfbZAUXwL1FCr44YJCN9HBZmL9Gj/folder_that_isnt_there', (err, res) => {
+      if (err !== null && res === undefined) {
+        done()
+      }
     })
   })
 })

--- a/test/api/ls.spec.js
+++ b/test/api/ls.spec.js
@@ -1,0 +1,19 @@
+'use strict'
+
+describe('ls', function () {
+  it('should correctly retrieve links', function (done) {
+    this.timeout(5000)
+    apiClients['a'].ls('QmTDH2RXGn8XyDAo9YyfbZAUXwL1FCr44YJCN9HBZmL9Gj', (err, res) => {
+      if (err) {
+        throw err
+      } else done()
+    })
+  })
+  it('should correctly throw errors', function (done) {
+    apiClients['a'].ls('surelynotavalidhashheh?', (err, res) => {
+      if (err === undefined) {
+        throw new Error()
+      } else done()
+    })
+  })
+})


### PR DESCRIPTION
While working with the API I noticed weird behavior in `ipfs.ls`. Sometimes it calls the callback twice and some other times when there's an error the error object is undefined and the response object is the actual error.

After talking briefly with @Dignifiedquire I've been trying to write tests to test these and also normal `ipfs.ls` functionality. Please let me know about anything wrong with the PR :+1:

Looks like I couldn't reproduce the issue I was having. I'll try again if I happen to run into it, but it was probably some mistake on my end.