### PR TITLE
Replace `require.context` with individual requires.

### DIFF
--- a/src/load-commands.js
+++ b/src/load-commands.js
@@ -2,25 +2,34 @@
 
 const isNode = !global.window
 
-function requireDir () {
+function requireCommands () {
   if (isNode) return require('require-dir')('./api')
 
-  // Webpack specific require of a directory
-  const req = require.context('./api', false, /\.js$/)
-
-  const files = {}
-  req.keys().forEach(key => {
-    const name = key
-      .replace(/^\.\//, '')
-      .replace(/\.js$/, '')
-    files[name] = req(key)
-  })
-
-  return files
+  return {
+    add: require('./api/add'),
+    block: require('./api/block'),
+    cat: require('./api/cat'),
+    commands: require('./api/commands'),
+    config: require('./api/config'),
+    dht: require('./api/dht'),
+    diag: require('./api/diag'),
+    id: require('./api/id'),
+    log: require('./api/log'),
+    ls: require('./api/ls'),
+    mount: require('./api/mount'),
+    name: require('./api/name'),
+    object: require('./api/object'),
+    pin: require('./api/pin'),
+    ping: require('./api/ping'),
+    refs: require('./api/refs'),
+    swarm: require('./api/swarm'),
+    update: require('./api/update'),
+    version: require('./api/version')
+  }
 }
 
 function loadCommands (send) {
-  const files = requireDir()
+  const files = requireCommands()
   const cmds = {}
 
   Object.keys(files).forEach(file => {


### PR DESCRIPTION
Webpack's `require.context` is transpiled only if ipfs-api is loaded or bundled
using webpack. This broke modules that require ipfs-api and use browserify or
other bundlers (such as webui)

Fixes ipfs/js-ipfs-api#159 by using individual requires. I opted for this because IMO maintaining a list of requires is less headache than dealing with the complexities of directory walking in different runtime contexts (browser, node, webpack, browserify, etc.)