### PR TITLE
Exclude port from path if `config.port` not set.

### DIFF
--- a/src/request-api.js
+++ b/src/request-api.js
@@ -90,9 +90,11 @@ function requestAPI (config, path, args, qs, files, buffer, cb) {
   // this option is only used internally, not passed to daemon
   delete qs.followSymlinks
 
+  const port = config.port ? `:${config.port}` : ''
+
   const opts = {
     method: files ? 'POST' : 'GET',
-    uri: `${config.protocol}://${config.host}:${config.port}${config['api-path']}${path}?${Qs.stringify(qs, {arrayFormat: 'repeat'})}`,
+    uri: `${config.protocol}://${config.host}${port}${config['api-path']}${path}?${Qs.stringify(qs, {arrayFormat: 'repeat'})}`,
     headers: {}
   }
 

--- a/test/request-api.spec.js
+++ b/test/request-api.spec.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const ipfsAPI = require('../src/index.js')
+const noop = () => {}
+
+describe('ipfsAPI request tests', () => {
+  describe('requestAPI', () => {
+    const apiAddrs = require('./tmp-disposable-nodes-addrs.json')
+    const apiAddr = apiAddrs.a.split('/')
+
+    it('excludes port from URL if config.port is falsy', (done) => {
+      const Wreck = require('wreck')
+      const request = Wreck.request
+
+      Wreck.request = (method, uri, opts, cb) => {
+        Wreck.request = request
+        expect(uri).to.not.contain(/:\d/)
+        done()
+      }
+
+      ipfsAPI({
+        host: apiAddr[2],
+        port: null,
+        protocol: 'http'
+      }).id(noop)
+    })
+
+    it('includes port in URL if config.port is truthy', (done) => {
+      const Wreck = require('wreck')
+      const request = Wreck.request
+
+      Wreck.request = (method, uri, opts, cb) => {
+        Wreck.request = request
+        expect(uri).to.contain(':' + apiAddr[4])
+        done()
+      }
+
+      ipfsAPI({
+        host: apiAddr[2],
+        port: apiAddr[4],
+        protocol: 'http'
+      }).id(noop)
+    })
+  })
+})


### PR DESCRIPTION
Fixes ipfs/js-ipfs-api#161. 