### PR TITLE
0.3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,10 @@ When using the api from script tag for things that require buffers (`ipfs.add`, 
 
 ## CORS
 
-If are using this module in a browser with something like browserify, then you will get an error saying that the origin is not allowed. This would be a CORS ("Cross Origin Resource Sharing") failure. The ipfs server rejects requests from unknown domains by default. You can whitelist the domain that you are calling from by exporting `API_ORIGIN` and restarting the daemon, like:
+If are using this module in a browser with something like browserify, then you will get an error saying that the origin is not allowed. This would be a CORS ("Cross Origin Resource Sharing") failure. The ipfs server rejects requests from unknown domains by default. You can whitelist the domain that you are calling from by changing your ipfs config like this:
 
 ```bash
-export API_ORIGIN="http://localhost:8080"
-ipfs daemon
+$ ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin "[\"http://example.com\"]"
 ```
 
 ## API

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "gulp-tag-version": "^1.3.0",
     "gulp-util": "^3.0.7",
     "https-browserify": "0.0.1",
-    "ipfsd-ctl": "^0.6.1",
+    "ipfsd-ctl": "^0.7.1",
     "json-loader": "^0.5.3",
     "karma": "^0.13.11",
     "karma-chrome-launcher": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "concurrently": "^1.0.0",
     "eslint-config-standard": "^4.4.0",
     "eslint-plugin-standard": "^1.3.1",
+    "glob-stream": "5.2.0",
     "gulp": "^3.9.0",
     "gulp-bump": "^1.0.0",
     "gulp-eslint": "^1.0.0",

--- a/src/request-api.js
+++ b/src/request-api.js
@@ -2,6 +2,7 @@
 
 const Wreck = require('wreck')
 const Qs = require('qs')
+const ndjson = require('ndjson')
 const getFilesStream = require('./get-files-stream')
 
 const isNode = !global.window
@@ -10,14 +11,10 @@ const isNode = !global.window
 
 function parseChunkedJson (res, cb) {
   const parsed = []
-  res.on('data', chunk => {
-    try {
-      parsed.push(JSON.parse(chunk))
-    } catch (err) {
-      // Browser quirks emit more than needed sometimes
-    }
-  })
-  res.on('end', () => cb(null, parsed))
+  res
+    .pipe(ndjson.parse())
+    .on('data', parsed.push.bind(parsed))
+    .on('end', () => cb(null, parsed))
 }
 
 function onRes (buffer, cb) {

--- a/tasks/daemons.js
+++ b/tasks/daemons.js
@@ -59,7 +59,10 @@ function startDisposableDaemons (callback) {
 
           const headers = {
             HTTPHeaders: {
-              'Access-Control-Allow-Origin': ['*']
+              'Access-Control-Allow-Origin': ['*'],
+              // TODO: When ipfs/go-ipfs#1979 is merged drop these
+              'Access-Control-Allow-Headers': ['X-Stream-Output, X-Chunked-Output'],
+              'Access-Control-Expose-Headers': ['X-Stream-Output, X-Chunked-Output']
             }
           }
           ipfsNodes[key].setConfig('API', JSON.stringify(headers), err => {

--- a/tasks/daemons.js
+++ b/tasks/daemons.js
@@ -59,10 +59,7 @@ function startDisposableDaemons (callback) {
 
           const headers = {
             HTTPHeaders: {
-              'Access-Control-Allow-Origin': ['*'],
-              // TODO: When ipfs/go-ipfs#1979 is merged drop these
-              'Access-Control-Allow-Headers': ['X-Stream-Output, X-Chunked-Output'],
-              'Access-Control-Expose-Headers': ['X-Stream-Output, X-Chunked-Output']
+              'Access-Control-Allow-Origin': ['*']
             }
           }
           ipfsNodes[key].setConfig('API', JSON.stringify(headers), err => {

--- a/test/api/ping.spec.js
+++ b/test/api/ping.spec.js
@@ -2,11 +2,6 @@
 
 describe('.ping', () => {
   it('ping another peer', done => {
-    // TODO remove this when https://github.com/ipfs/js-ipfs-api/issues/135 is resolved
-    if (!isNode) {
-      return done()
-    }
-
     apiClients['b'].id((err, id) => {
       expect(err).to.not.exist
 


### PR DESCRIPTION
I've started this, found a bug, but seems to be on the gulp karma task and not js-ipfs-api itself, tests print a ton more stuff then they used too.


Running the tests on master yield the same error, @Dignifiedquire any ideas? My first thought is that there was some patch upgrade in some of the babel+gulp+karma dependencies that broke things, which makes sense why all greenkeeper PRs now warn of breaking build

moved to [gist](https://gist.github.com/Dignifiedquire/4c144b1f2814944074c4)