### PR TITLE
Fixes #124 (Cannot declare a parameter named 'mask' as it shadows the name of a strict mode function)

### DIFF
--- a/src/api/id.js
+++ b/src/api/id.js
@@ -1,11 +1,11 @@
 'use strict'
 
 module.exports = send => {
-  return function id (id, cb) {
-    if (typeof id === 'function') {
-      cb = id
-      id = null
+  return function id (idParam, cb) {
+    if (typeof idParam === 'function') {
+      cb = idParam
+      idParam = null
     }
-    return send('id', id, null, null, cb)
+    return send('id', idParam, null, null, cb)
   }
 }


### PR DESCRIPTION
I renamed the parameter so it doesn't collide
Related to #124