### PR TITLE
fix(request): Improve json content-type detection

### DIFF
--- a/src/request-api.js
+++ b/src/request-api.js
@@ -25,7 +25,7 @@ function onRes (buffer, cb) {
 
     const stream = !!res.headers['x-stream-output']
     const chunkedObjects = !!res.headers['x-chunked-output']
-    const isJson = res.headers['content-type'] === 'application/json'
+    const isJson = res.headers['content-type'].indexOf('application/json') === 0
 
     if (res.statusCode >= 400 || !res.statusCode) {
       const error = new Error(`Server responded with ${res.statusCode}`)


### PR DESCRIPTION
js-ipfs serves a content type including the charset
`application/json; charset=utf-8` so the previous check for
json failed, resulting in non parsed json.
Fixes https://github.com/ipfs/js-ipfs/pull/69/files#r53560321