### PR TITLE
Avoid crash for responses without 'content-type' header

### DIFF
--- a/src/request-api.js
+++ b/src/request-api.js
@@ -25,7 +25,7 @@ function onRes (buffer, cb) {
 
     const stream = !!res.headers['x-stream-output']
     const chunkedObjects = !!res.headers['x-chunked-output']
-    const isJson = res.headers['content-type'].indexOf('application/json') === 0
+    const isJson = res.headers['content-type'] && res.headers['content-type'].indexOf('application/json') === 0
 
     if (res.statusCode >= 400 || !res.statusCode) {
       const error = new Error(`Server responded with ${res.statusCode}`)

--- a/test/request-api.spec.js
+++ b/test/request-api.spec.js
@@ -41,5 +41,24 @@ describe('ipfsAPI request tests', () => {
         protocol: 'http'
       }).id(noop)
     })
+
+    it('does not crash if no content-type header is provided', (done) => {
+      if (!isNode) {
+        return done()
+      }
+
+      // go-ipfs always (currently) adds a content-type header, even if no content is present,
+      // the standard behaviour for an http-api is to omit this header if no content is present
+      const server = require('http').createServer((req, res) => {
+        res.writeHead(200)
+        res.end()
+      }).listen(6001, () => {
+        ipfsAPI('/ip4/127.0.0.1/tcp/6001')
+          .config.replace('test/r-config.json', (err) => {
+            expect(err).to.be.equal(null)
+            server.close(done)
+          })
+      })
+    })
   })
 })


### PR DESCRIPTION
For example, when the response is a 200 OK without body