### PR TITLE
test: extend block coverage

### DIFF
--- a/src/api/block.js
+++ b/src/api/block.js
@@ -9,7 +9,7 @@ module.exports = (send) => {
     put (file, cb) {
       if (Array.isArray(file)) {
         let err = new Error('block.put() only accepts 1 file')
-        if (typeof cb !== 'function') {
+        if (typeof cb !== 'function' && typeof Promise !== 'undefined') {
           return new Promise((resolve, reject) => reject(err))
         }
         return cb(err)

--- a/src/api/block.js
+++ b/src/api/block.js
@@ -8,7 +8,11 @@ module.exports = (send) => {
     stat: argCommand(send, 'block/stat'),
     put (file, cb) {
       if (Array.isArray(file)) {
-        return cb(null, new Error('block.put() only accepts 1 file'))
+        let err = new Error('block.put() only accepts 1 file')
+        if (typeof cb !== 'function') {
+          return new Promise((resolve, reject) => reject(err))
+        }
+        return cb(err)
       }
       return send('block/put', null, null, file, cb)
     }

--- a/test/api/block.spec.js
+++ b/test/api/block.spec.js
@@ -8,6 +8,12 @@ describe('.block', () => {
   const blorbKey = 'QmPv52ekjS75L4JmHpXVeuJ5uX2ecSfSZo88NSyxwA3rAQ'
   const blorb = Buffer('blorb')
 
+  it('returns an error when putting an array of files', () => {
+    return apiClients.a.block.put([blorb, blorb], (err) => {
+      expect(err).to.be.an.instanceof(Error)
+    })
+  })
+
   it('block.put', (done) => {
     apiClients.a.block.put(blorb, (err, res) => {
       expect(err).to.not.exist
@@ -40,6 +46,13 @@ describe('.block', () => {
   })
 
   describe('promise', () => {
+    it('returns an error when putting an array of files', () => {
+      return apiClients.a.block.put([blorb, blorb])
+        .catch((err) => {
+          expect(err).to.be.an.instanceof(Error)
+        })
+    })
+
     it('block.put', () => {
       return apiClients.a.block.put(blorb)
         .then((res) => {


### PR DESCRIPTION
`block.put` now returns a rejected promise when no callback is provided and an error occurs; more tests.