### PR TITLE
require `bl` version `^1.1.2` in order to fix #275

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",
   "dependencies": {
+    "bl": "^1.1.2",
     "babel-runtime": "^6.6.1",
     "bs58": "^3.0.0",
     "detect-node": "^2.0.3",


### PR DESCRIPTION
This pull request adds the newest [`bl`](https://www.npmjs.com/package/bl) to `dependencies`. It is intended to fix #275.

A (previuosly missing) linebreak is added to the file's ending because that's how the browser-based editor works on GitHub.