### PR TITLE
WIP cat interface core

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "flatmap": "0.0.3",
     "glob": "^7.0.3",
     "ipfs-merkle-dag": "^0.6.0",
+    "is-ipfs": "^0.2.0",
     "multiaddr": "^2.0.0",
     "multipart-stream": "^2.0.1",
     "ndjson": "^1.4.3",

--- a/src/api/cat.js
+++ b/src/api/cat.js
@@ -1,7 +1,32 @@
 'use strict'
 
-const argCommand = require('../cmd-helpers').argCommand
+const bs58 = require('bs58')
+const isIPFS = require('is-ipfs')
+const promisify = require('promisify-es6')
 
 module.exports = (send) => {
-  return argCommand(send, 'cat')
+  const cat = promisify((multihash, callback) => {
+    try {
+      multihash = cleanMultihash(multihash)
+    } catch (err) {
+      return callback(err)
+    }
+    send('cat', multihash, null, null, function (err, result) {
+      if (err) {
+        return callback(err)
+      }
+      return callback(null, result)
+    })
+  })
+  return cat
+}
+
+function cleanMultihash (multihash) {
+  if (!isIPFS.multihash(multihash)) {
+    throw new Error('not valid multihash')
+  }
+  if (Buffer.isBuffer(multihash)) {
+    return bs58.encode(multihash)
+  }
+  return multihash
 }

--- a/test/api/file.spec.js
+++ b/test/api/file.spec.js
@@ -1,0 +1,17 @@
+/* eslint-env mocha */
+/* globals apiClients */
+
+'use strict'
+
+const test = require('interface-ipfs-core')
+
+const common = {
+  setup: function (cb) {
+    cb(null, apiClients.a)
+  },
+  teardown: function (cb) {
+    cb()
+  }
+}
+
+test.files(common)


### PR DESCRIPTION
This begins the js-ipfs-api cat command using the interace-core tests shared with the js-ipfs core tests.

This needs the completition of the cat interface-core <a href="https://github.com/ipfs/interface-ipfs-core/pull/21">PR</a>