### PR TITLE
Include directory in pattern

### DIFF
--- a/src/get-files-stream.js
+++ b/src/get-files-stream.js
@@ -44,7 +44,7 @@ function loadPaths (opts, file) {
   }
 
   if (stats.isDirectory() && opts.recursive) {
-    const mg = new glob.sync.GlobSync(`${file}/**/*`, {
+    const mg = new glob.sync.GlobSync(`${file}/**`, {
       follow: followSymlinks
     })
 


### PR DESCRIPTION
Prevents issue where the actual directory is not included when adding a directory with addFiles.

`addFiles('/usr/src/app')` would for example match everything inside `/usr/src/app` but not `/usr/src/app` itself.