### PR TITLE
update get-dagNode for buffers

### DIFF
--- a/src/get-dagnode.js
+++ b/src/get-dagnode.js
@@ -27,12 +27,16 @@ module.exports = function (send, hash, cb) {
       var object = res[0]
       var stream = res[1]
 
-      stream.pipe(bl(function (err, data) {
-        if (err) {
-          return cb(err)
-        }
+      if (Buffer.isBuffer(stream)) {
+        cb(err, new DAGNode(stream, object.Links))
+      } else {
+        stream.pipe(bl(function (err, data) {
+          if (err) {
+            return cb(err)
+          }
 
-        cb(err, new DAGNode(data, object.Links))
-      }))
+          cb(err, new DAGNode(data, object.Links))
+        }))
+      }
     })
 }


### PR DESCRIPTION
#This adds a check for the response from the go/js daemons to see if data is sending a stream or a buffer. This is needed for <a href="https://github.com/ipfs/js-ipfs/pull/323">PR</a>

@noffle for CR