### PR TITLE
alias for add and createAddStream.

### DIFF
--- a/src/load-commands.js
+++ b/src/load-commands.js
@@ -2,6 +2,8 @@
 
 function requireCommands () {
   const cmds = {
+    add: require('./api/add'), // add alias
+    createAddStream: require('./api/add-stream'), // add stream alias
     bitswap: require('./api/bitswap'),
     block: require('./api/block'),
     bootstrap: require('./api/bootstrap'),
@@ -30,9 +32,7 @@ function requireCommands () {
     const files = require('./api/files')(send)
     files.add = require('./api/add')(send)
     files.createAddStream = require('./api/add-stream.js')(send)
-    // aliases
-    cmds.add = files.add
-    cmds.createAddStream = files.createAddStream
+
     return files
   }
 


### PR DESCRIPTION
Currently calling ```ipfs.add``` and ```ipfs.createAddStream``` will fail since the alias isn't picked up until after the ```ipfs.files``` command is called. 

Not sure if this is the best approach but this will allow people to use add with or without files until the namespace collision is solved.

This was referenced in issue #301 

@noffle could you check this and see if there could be any issues aliasing this way instead of how you had it.