### PR TITLE
Adding repo API methods supported by ipfs 0.4.1

### DIFF
--- a/src/api/repo.js
+++ b/src/api/repo.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const cmds = require('../cmd-helpers')
+
+module.exports = (send) => {
+  return {
+    gc: cmds.command(send, 'repo/gc'),
+    stat: cmds.command(send, 'repo/stat')
+  }
+}

--- a/src/load-commands.js
+++ b/src/load-commands.js
@@ -21,6 +21,7 @@ function requireCommands () {
     pin: require('./api/pin'),
     ping: require('./api/ping'),
     refs: require('./api/refs'),
+    repo: require('./api/repo'),
     swarm: require('./api/swarm'),
     update: require('./api/update'),
     version: require('./api/version')

--- a/test/api/repo.spec.js
+++ b/test/api/repo.spec.js
@@ -1,0 +1,43 @@
+/* eslint-env mocha */
+/* globals apiClients */
+'use strict'
+
+const expect = require('chai').expect
+
+describe('.repo', () => {
+  it('.repo.gc', (done) => {
+    apiClients.a.repo.gc((err, res) => {
+      expect(err).to.not.exist
+      expect(res).to.exist
+      done()
+    })
+  })
+
+  it('.repo.stat', (done) => {
+    apiClients.a.repo.stat((err, res) => {
+      expect(err).to.not.exist
+      expect(res).to.exist
+      expect(res).to.have.a.property('NumObjects')
+      expect(res).to.have.a.property('RepoSize')
+      done()
+    })
+  })
+
+  describe('promise', () => {
+    it('.repo.gc', () => {
+      return apiClients.a.repo.gc()
+        .then((res) => {
+          expect(res).to.exist
+        })
+    })
+
+    it('.repo.stat', () => {
+      return apiClients.a.repo.stat()
+        .then((res) => {
+          expect(res).to.exist
+          expect(res).to.have.a.property('NumObjects')
+          expect(res).to.have.a.property('RepoSize')
+        })
+    })
+  })
+})


### PR DESCRIPTION
This adds support and test coverage for `repo.gc` and `repo.stat`, the two `repo` API methods supported by IPFS v0.4.1.

Support for other `repo` methods available in IPFS v0.4.2 depends on a pending update to the js-ipfsd-ctl dev dependency: https://github.com/ipfs/js-ipfsd-ctl/pull/80
