### PR TITLE
feat(deps): update aegir

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "url": "https://github.com/ipfs/js-ipfs-api"
   },
   "devDependencies": {
-    "aegir": "^6.0.0",
+    "aegir": "^7.0.0",
     "chai": "^3.5.0",
     "gulp": "^3.9.1",
     "hapi": "^14.1.0",


### PR DESCRIPTION
Currently, PhantomJS tests fail with new aegir. Discovered with: https://github.com/ipfs/js-ipfs-api/pull/354#issuecomment-242066621

