### PR TITLE
fix: Return req from tail

### DIFF
--- a/src/api/log.js
+++ b/src/api/log.js
@@ -6,7 +6,7 @@ const promisify = require('promisify-es6')
 module.exports = (send) => {
   return {
     tail: promisify((callback) => {
-      send({
+      return send({
         path: 'log/tail'
       }, (err, response) => {
         if (err) {


### PR DESCRIPTION
This fixes the broken master-build. Something worrying is that this doesn't always fail (the test for log.tail) when running all tests with `npm test`, but when running only that test, it always fails.

This PR should pass all CI though. 