### PR TITLE
refactor(streams): Refactor response stream handling.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "async": "^2.1.4",
-    "bl": "^1.1.2",
     "bs58": "^4.0.0",
     "concat-stream": "^1.6.0",
     "detect-node": "^2.0.3",
@@ -43,6 +42,7 @@
     "peer-id": "^0.8.1",
     "peer-info": "^0.8.1",
     "promisify-es6": "^1.0.2",
+    "pump": "^1.0.2",
     "qs": "^6.3.0",
     "readable-stream": "1.1.14",
     "stream-http": "^2.5.0",

--- a/src/api/dht.js
+++ b/src/api/dht.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const promisify = require('promisify-es6')
+const streamToValue = require('../stream-to-value')
 
 module.exports = (send) => {
   return {
@@ -19,11 +20,13 @@ module.exports = (send) => {
         opts = {}
       }
 
-      send({
+      const request = {
         path: 'dht/findprovs',
         args: args,
         qs: opts
-      }, callback)
+      }
+
+      send.andTransform(request, streamToValue, callback)
     }),
     get: promisify((key, opts, callback) => {
       if (typeof opts === 'function' &&

--- a/src/api/get.js
+++ b/src/api/get.js
@@ -33,6 +33,6 @@ module.exports = (send) => {
     }
 
     // Convert the response stream to TarStream objects
-    send.andTransform(request, TarStreamToObjects.from, callback)
+    send.andTransform(request, TarStreamToObjects, callback)
   })
 }

--- a/src/api/get.js
+++ b/src/api/get.js
@@ -1,11 +1,11 @@
 'use strict'
 
-const tarStreamToObjects = require('../tar-stream-to-objects')
-const cleanMultihash = require('../clean-multihash')
 const promisify = require('promisify-es6')
+const cleanMultihash = require('../clean-multihash')
+const TarStreamToObjects = require('../tar-stream-to-objects')
 
 module.exports = (send) => {
-  return promisify(function get (path, opts, callback) {
+  return promisify((path, opts, callback) => {
     if (typeof opts === 'function' &&
         !callback) {
       callback = opts
@@ -26,12 +26,13 @@ module.exports = (send) => {
       return callback(err)
     }
 
-    var sendWithTransform = send.withTransform(tarStreamToObjects)
-
-    sendWithTransform({
+    const request = {
       path: 'get',
       args: path,
       qs: opts
-    }, callback)
+    }
+
+    // Convert the response stream to TarStream objects
+    send.andTransform(request, TarStreamToObjects.from, callback)
   })
 }

--- a/src/api/log.js
+++ b/src/api/log.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const pump = require('pump')
 const ndjson = require('ndjson')
 const promisify = require('promisify-es6')
 
@@ -12,7 +13,8 @@ module.exports = (send) => {
         if (err) {
           return callback(err)
         }
-        callback(null, response.pipe(ndjson.parse()))
+        const outputStream = pump(response, ndjson.parse())
+        callback(null, outputStream)
       })
     })
   }

--- a/src/api/object.js
+++ b/src/api/object.js
@@ -5,7 +5,7 @@ const DAGNode = dagPB.DAGNode
 const DAGLink = dagPB.DAGLink
 const promisify = require('promisify-es6')
 const bs58 = require('bs58')
-const bl = require('bl')
+const streamToValue = require('../stream-to-value')
 const cleanMultihash = require('../clean-multihash')
 const LRU = require('lru-cache')
 const lruOptions = {
@@ -188,7 +188,7 @@ module.exports = (send) => {
         }
 
         if (typeof result.pipe === 'function') {
-          result.pipe(bl(callback))
+          streamToValue(result, callback)
         } else {
           callback(null, result)
         }

--- a/src/api/ping.js
+++ b/src/api/ping.js
@@ -1,18 +1,36 @@
 'use strict'
 
 const promisify = require('promisify-es6')
+const streamToValue = require('../stream-to-value')
 
 module.exports = (send) => {
   return promisify((id, callback) => {
-    send({
+    const request = {
       path: 'ping',
       args: id,
       qs: { n: 1 }
-    }, function (err, res) {
-      if (err) {
-        return callback(err, null)
-      }
-      callback(null, res[1])
-    })
+    }
+
+    // Transform the response stream to a value:
+    // { Success: <boolean>, Time: <number>, Text: <string> }
+    const transform = (res, callback) => {
+      streamToValue(res, (err, res) => {
+        if (err) {
+          return callback(err)
+        }
+
+        // go-ipfs http api currently returns 3 lines for a ping.
+        // they're a little messed, so take the correct values from each lines.
+        const pingResult = {
+          Success: res[1].Success,
+          Time: res[1].Time,
+          Text: res[2].Text
+        }
+
+        callback(null, pingResult)
+      })
+    }
+
+    send.andTransform(request, transform, callback)
   })
 }

--- a/src/api/refs.js
+++ b/src/api/refs.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const promisify = require('promisify-es6')
+const streamToValue = require('../stream-to-value')
 
 module.exports = (send) => {
   const refs = promisify((args, opts, callback) => {
@@ -8,21 +9,28 @@ module.exports = (send) => {
       callback = opts
       opts = {}
     }
-    return send({
+
+    const request = {
       path: 'refs',
       args: args,
       qs: opts
-    }, callback)
+    }
+
+    send.andTransform(request, streamToValue, callback)
   })
+
   refs.local = promisify((opts, callback) => {
     if (typeof (opts) === 'function') {
       callback = opts
       opts = {}
     }
-    return send({
+
+    const request = {
       path: 'refs',
       qs: opts
-    }, callback)
+    }
+
+    send.andTransform(request, streamToValue, callback)
   })
 
   return refs

--- a/src/api/util/fs-add.js
+++ b/src/api/util/fs-add.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const isNode = require('detect-node')
-const addToDagNodesTransform = require('./../../add-to-dagnode-transform')
 const promisify = require('promisify-es6')
+const DAGNodeStream = require('../../dagnode-stream')
 
 module.exports = (send) => {
   return promisify((path, opts, callback) => {
@@ -28,12 +28,14 @@ module.exports = (send) => {
       return callback(new Error('"path" must be a string'))
     }
 
-    const sendWithTransform = send.withTransform(addToDagNodesTransform)
-
-    sendWithTransform({
+    const request = {
       path: 'add',
       qs: opts,
       files: path
-    }, callback)
+    }
+
+    // Transform the response stream to DAGNode values
+    const transform = (res, callback) => DAGNodeStream.streamToValue(send, res, callback)
+    send.andTransform(request, transform, callback)
   })
 }

--- a/src/dagnode-stream.js
+++ b/src/dagnode-stream.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const pump = require('pump')
 const TransformStream = require('readable-stream').Transform
 const streamToValue = require('./stream-to-value')
 const getDagNode = require('./get-dagnode')
@@ -31,7 +32,9 @@ class DAGNodeStream extends TransformStream {
   }
 
   static streamToValue (send, inputStream, callback) {
-    const outputStream = inputStream.pipe(new DAGNodeStream({ send: send }))
+    const outputStream = pump(inputStream, new DAGNodeStream({ send: send }), (err) => {
+      if (err) callback(err)
+    })
     streamToValue(outputStream, callback)
   }
 

--- a/src/dagnode-stream.js
+++ b/src/dagnode-stream.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const TransformStream = require('readable-stream').Transform
+const streamToValue = require('./stream-to-value')
+const getDagNode = require('./get-dagnode')
+
+/*
+  Transforms a stream of objects to DAGNodes and outputs them as objects.
+
+  Usage: inputStream.pipe(DAGNodeStream({ send: send }))
+
+  Input object format:
+  {
+    Name: '/path/to/file/foo.txt',
+    Hash: 'Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP'
+  }
+
+  Output object format:
+  {
+    path: '/path/to/file/foo.txt',
+    hash: 'Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP',
+    size: 20
+  }
+*/
+class DAGNodeStream extends TransformStream {
+  constructor (options) {
+    const opts = Object.assign(options || {}, { objectMode: true })
+    super(opts)
+    this._send = opts.send
+  }
+
+  static streamToValue (send, inputStream, callback) {
+    const outputStream = inputStream.pipe(new DAGNodeStream({ send: send }))
+    streamToValue(outputStream, callback)
+  }
+
+  _transform (obj, enc, callback) {
+    getDagNode(this._send, obj.Hash, (err, node) => {
+      if (err) {
+        return callback(err)
+      }
+
+      const dag = {
+        path: obj.Name,
+        hash: obj.Hash,
+        size: node.size
+      }
+
+      this.push(dag)
+      callback(null)
+    })
+  }
+}
+
+module.exports = DAGNodeStream

--- a/src/dagnode-stream.js
+++ b/src/dagnode-stream.js
@@ -33,7 +33,9 @@ class DAGNodeStream extends TransformStream {
 
   static streamToValue (send, inputStream, callback) {
     const outputStream = pump(inputStream, new DAGNodeStream({ send: send }), (err) => {
-      if (err) callback(err)
+      if (err) {
+        callback(err)
+      }
     })
     streamToValue(outputStream, callback)
   }

--- a/src/dagnode-stream.js
+++ b/src/dagnode-stream.js
@@ -41,13 +41,13 @@ class DAGNodeStream extends TransformStream {
         return callback(err)
       }
 
-      const dag = {
+      const result = {
         path: obj.Name,
         hash: obj.Hash,
         size: node.size
       }
 
-      this.push(dag)
+      this.push(result)
       callback(null)
     })
   }

--- a/src/dagnode-stream.js
+++ b/src/dagnode-stream.js
@@ -5,7 +5,8 @@ const streamToValue = require('./stream-to-value')
 const getDagNode = require('./get-dagnode')
 
 /*
-  Transforms a stream of objects to DAGNodes and outputs them as objects.
+  Transforms a stream of {Name, Hash} objects to include size
+  of the DAG object.
 
   Usage: inputStream.pipe(DAGNodeStream({ send: send }))
 

--- a/src/get-dagnode.js
+++ b/src/get-dagnode.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const DAGNode = require('ipld-dag-pb').DAGNode
-const bl = require('bl')
 const parallel = require('async/parallel')
+const streamToValue = require('./stream-to-value')
 
 module.exports = function (send, hash, callback) {
   // Retrieve the object and its data in parallel, then produce a DAGNode
@@ -36,12 +36,12 @@ module.exports = function (send, hash, callback) {
       if (Buffer.isBuffer(stream)) {
         DAGNode.create(stream, object.Links, callback)
       } else {
-        stream.pipe(bl(function (err, data) {
+        streamToValue(stream, (err, data) => {
           if (err) {
             return callback(err)
           }
           DAGNode.create(data, object.Links, callback)
-        }))
+        })
       }
     })
 }

--- a/src/request-api.js
+++ b/src/request-api.js
@@ -3,6 +3,7 @@
 const Qs = require('qs')
 const isNode = require('detect-node')
 const ndjson = require('ndjson')
+const pump = require('pump')
 const once = require('once')
 const getFilesStream = require('./get-files-stream')
 const streamToValue = require('./stream-to-value')
@@ -43,7 +44,8 @@ function onRes (buffer, cb) {
 
     // Return a stream of JSON objects
     if (chunkedObjects && isJson) {
-      return cb(null, res.pipe(ndjson.parse()))
+      const outputStream = pump(res, ndjson.parse())
+      return cb(null, outputStream)
     }
 
     // Return a JSON object

--- a/src/request-api.js
+++ b/src/request-api.js
@@ -152,6 +152,10 @@ exports = module.exports = (config) => {
     return requestAPI(config, options, callback)
   }
 
+  // Send a HTTP request and pass via a transform function
+  // to convert the response data to wanted format before
+  // returning it to the callback.
+  // Eg. send.andTransform({}, (e) => JSON.parse(e), (err, res) => ...)
   send.andTransform = (options, transform, callback) => {
     return send(options, (err, res) => {
       if (err) {

--- a/src/stream-to-json-value.js
+++ b/src/stream-to-json-value.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const streamToValue = require('./stream-to-value')
+
+/*
+  Converts a stream to a single JSON value
+*/
+function streamToJsonValue (res, cb) {
+  streamToValue(res, (err, data) => {
+    if (err) {
+      return cb(err)
+    }
+
+    if (!data || data.length === 0) {
+      return cb()
+    }
+
+    // TODO: check if needed, afaik JSON.parse can parse Buffers
+    if (Buffer.isBuffer(data)) {
+      data = data.toString()
+    }
+
+    let res
+    try {
+      res = JSON.parse(data)
+    } catch (err) {
+      return cb(err)
+    }
+
+    cb(null, res)
+  })
+}
+
+module.exports = streamToJsonValue

--- a/src/stream-to-value.js
+++ b/src/stream-to-value.js
@@ -1,12 +1,16 @@
 'use strict'
 
+const pump = require('pump')
 const concat = require('concat-stream')
 
 /*
   Concatenate a stream to a single value.
 */
 function streamToValue (res, callback) {
-  res.pipe(concat((data) => callback(null, data)))
+  const done = (data) => callback(null, data)
+  pump(res, concat(done), (err) => {
+    if (err) callback(err)
+  })
 }
 
 module.exports = streamToValue

--- a/src/stream-to-value.js
+++ b/src/stream-to-value.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const concat = require('concat-stream')
+
+/*
+  Concatenate a stream to a single value.
+*/
+function streamToValue (res, callback) {
+  res.pipe(concat((data) => callback(null, data)))
+}
+
+module.exports = streamToValue

--- a/src/stringlist-to-array.js
+++ b/src/stringlist-to-array.js
@@ -1,0 +1,9 @@
+'use strict'
+
+// Converts a go-ipfs "stringList" to an array
+// { Strings: ['A', 'B'] } --> ['A', 'B']
+function stringlistToArray (res, cb) {
+  cb(null, res.Strings || [])
+}
+
+module.exports = stringlistToArray

--- a/src/tar-stream-to-objects.js
+++ b/src/tar-stream-to-objects.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const pump = require('pump')
 const tar = require('tar-stream')
 const ReadableStream = require('readable-stream').Readable
 
@@ -9,7 +10,7 @@ class ObjectsStreams extends ReadableStream {
     super(opts)
   }
 
-  _read ()  {}
+  _read () {}
 }
 
 /*
@@ -20,9 +21,9 @@ class ObjectsStreams extends ReadableStream {
 */
 const TarStreamToObjects = (inputStream, callback) => {
   let outputStream = new ObjectsStreams()
+  let extractStream = tar.extract()
 
-  inputStream
-    .pipe(tar.extract())
+  extractStream
     .on('entry', (header, stream, next) => {
       stream.on('end', next)
 
@@ -40,6 +41,7 @@ const TarStreamToObjects = (inputStream, callback) => {
     })
     .on('finish', () => outputStream.push(null))
 
+  pump(inputStream, extractStream)
   callback(null, outputStream)
 }
 

--- a/test/interface-ipfs-core/ping.spec.js
+++ b/test/interface-ipfs-core/ping.spec.js
@@ -12,6 +12,10 @@ describe('.ping', () => {
       apiClients.a.ping(id.id, (err, res) => {
         expect(err).to.not.exist
         expect(res).to.have.a.property('Success')
+        expect(res).to.have.a.property('Time')
+        expect(res).to.have.a.property('Text')
+        expect(res.Text).to.contain('Average latency')
+        expect(res.Time).to.be.a('number')
         done()
       })
     })
@@ -25,6 +29,10 @@ describe('.ping', () => {
         })
         .then((res) => {
           expect(res).to.have.a.property('Success')
+          expect(res).to.have.a.property('Time')
+          expect(res).to.have.a.property('Text')
+          expect(res.Text).to.contain('Average latency')
+          expect(res.Time).to.be.a('number')
         })
     })
   })

--- a/test/interface-ipfs-core/refs.spec.js
+++ b/test/interface-ipfs-core/refs.spec.js
@@ -65,7 +65,6 @@ describe('.refs', () => {
     ipfs.refs(folder, {format: '<src> <dst> <linkname>'}, (err, objs) => {
       expect(err).to.not.exist
       expect(objs).to.eql(result)
-
       done()
     })
   })

--- a/test/ipfs-api/util.spec.js
+++ b/test/ipfs-api/util.spec.js
@@ -65,7 +65,6 @@ describe('.util', () => {
     ipfs.util.addFromFs(filePath, (err, result) => {
       expect(err).to.not.exist
       expect(result.length).to.be.above(5)
-
       done()
     })
   })

--- a/test/setup/spawn-daemons.js
+++ b/test/setup/spawn-daemons.js
@@ -28,9 +28,11 @@ function startDisposableDaemons (callback) {
       const configValues = {
         Bootstrap: [],
         Discovery: {},
-        'HTTPHeaders.Access-Control-Allow-Origin': ['*'],
-        'HTTPHeaders.Access-Control-Allow-Credentials': 'true',
-        'HTTPHeaders.Access-Control-Allow-Methods': ['PUT', 'POST', 'GET']
+        API: {
+          'HTTPHeaders.Access-Control-Allow-Origin': ['*'],
+          'HTTPHeaders.Access-Control-Allow-Credentials': 'true',
+          'HTTPHeaders.Access-Control-Allow-Methods': ['PUT', 'POST', 'GET']
+        }
       }
 
       eachSeries(Object.keys(configValues), (configKey, cb) => {

--- a/test/setup/spawn-daemons.js
+++ b/test/setup/spawn-daemons.js
@@ -28,15 +28,13 @@ function startDisposableDaemons (callback) {
       const configValues = {
         Bootstrap: [],
         Discovery: {},
-        API: {
-          'HTTPHeaders.Access-Control-Allow-Origin': ['*'],
-          'HTTPHeaders.Access-Control-Allow-Credentials': 'true',
-          'HTTPHeaders.Access-Control-Allow-Methods': ['PUT', 'POST', 'GET']
-        }
+        'API.HTTPHeaders.Access-Control-Allow-Origin': ['*'],
+        'API.HTTPHeaders.Access-Control-Allow-Credentials': 'true',
+        'API.HTTPHeaders.Access-Control-Allow-Methods': ['PUT', 'POST', 'GET']
       }
 
       eachSeries(Object.keys(configValues), (configKey, cb) => {
-        nodes[key].setConfig(`API.${configKey}`, JSON.stringify(configValues[configKey]), cb)
+        nodes[key].setConfig(configKey, JSON.stringify(configValues[configKey]), cb)
       }, (err) => {
         if (err) {
           return cb(err)


### PR DESCRIPTION
This PR will:

- Refactor the response stream handling.
- Add dagnode-stream to transform file results to DAGNode objects.
- Add stream-to-value to convert a response stream to a single value.
- Refactor request-api so that chunked JSON objects are not buffered anymore. This touches a bunch of the files pushing the transform function down to the individual commands.

The general idea in this PR is to  cleanup the architecture and implementation regards to how the http responses are handled. Previously some of it was done in request-api.js and some in the individual commands making request-api coupled with the commands' response type. I've moved the response transform logic down to the individual commands so that request-api is agnostic to what is returned to the consumer of the commands. I've also refactored individual types of transformations to their own files to make it clear, clean and much more reusable (we can consider moving them to their own modules, but not in this PR).