### PR TITLE
fix so that multihashes may be followed by sub-path strings

### DIFF
--- a/src/clean-multihash.js
+++ b/src/clean-multihash.js
@@ -4,11 +4,14 @@ const bs58 = require('bs58')
 const isIPFS = require('is-ipfs')
 
 module.exports = function (multihash) {
-  if (!isIPFS.multihash(multihash)) {
-    throw new Error('not valid multihash')
-  }
   if (Buffer.isBuffer(multihash)) {
-    return bs58.encode(multihash)
+    multihash = bs58.encode(multihash)
+  }
+  if (typeof multihash !== 'string') {
+    throw new Error('unexpected multihash type: ' + typeof multihash)
+  }
+  if (!isIPFS.multihash(multihash.split('/')[0])) {
+    throw new Error('not valid multihash')
   }
   return multihash
 }


### PR DESCRIPTION
In the command-line tool you can have a hash followed by a path:

``` sh
ipfs cat QmXJ8KkgKyjRxTrEDvmZWZMNGq1dk3t97AVhF1Xeov3kB4/meta.json
```

Using ipfs-api before this patch I would get these errors when I try to do the same thing:

```
not valid multihash
```

With this patch, I get the expected output, the same as the command-line tool.