### PR TITLE
Adding ignore globs to fsadd.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 test/setup/tmp-disposable-nodes-addrs.json
 dist
 coverage
+**/*.swp

--- a/README.md
+++ b/README.md
@@ -150,10 +150,10 @@ Complete documentation for these methods is coming with: https://github.com/ipfs
 
 > `ipfs.util.addFromFs(path, option, callback)`
 
-Reads a file from `path` on the filesystem  and adds it to IPFS. If `path` is a directory, use option `{ recursive: true }` to add the directory and all its sub-directories.
+Reads a file from `path` on the filesystem  and adds it to IPFS. If `path` is a directory, use option `{ recursive: true }` to add the directory and all its sub-directories. To exclude fileglobs from the directory, use option `{ ignore: ['ignore/this/folder/**', 'and/this/file'] }`.
 
 ```JavaScript
-ipfs.util.addFromFs('path/to/a/file', { recursive: true }, (err, result) => {
+ipfs.util.addFromFs('path/to/a/folder', { recursive: true , ignore: ['subfolder/to/ignore/**']}, (err, result) => {
   if (err) {
     throw err
   }

--- a/src/get-files-stream.js
+++ b/src/get-files-stream.js
@@ -45,8 +45,12 @@ function loadPaths (opts, file) {
   }
 
   if (stats.isDirectory() && opts.recursive) {
-    const mg = new glob.sync.GlobSync(`${escape(file)}/**/*`, {
-      follow: followSymlinks
+    const globEscapedDir = escape(file) + (file.endsWith('/') ? '' : '/')
+    const mg = new glob.sync.GlobSync(`${globEscapedDir}**/*`, {
+      follow: followSymlinks,
+      ignore: (opts.ignore || []).map(function(ignoreGlob) {
+        return globEscapedDir + ignoreGlob
+      })
     })
 
     return mg.found
@@ -88,7 +92,7 @@ function loadPaths (opts, file) {
   }
 
   return {
-    path: file,
+    path: path.basename(file),
     content: fs.createReadStream(file)
   }
 }

--- a/src/get-files-stream.js
+++ b/src/get-files-stream.js
@@ -48,7 +48,7 @@ function loadPaths (opts, file) {
     const globEscapedDir = escape(file) + (file.endsWith('/') ? '' : '/')
     const mg = new glob.sync.GlobSync(`${globEscapedDir}**/*`, {
       follow: followSymlinks,
-      ignore: (opts.ignore || []).map(function(ignoreGlob) {
+      ignore: (opts.ignore || []).map(function (ignoreGlob) {
         return globEscapedDir + ignoreGlob
       })
     })

--- a/test/ipfs-api/util.spec.js
+++ b/test/ipfs-api/util.spec.js
@@ -59,10 +59,10 @@ describe('.util', () => {
       done()
     })
   })
-  
+
   it('.fsAdd add and ignore a directory', (done) => {
     const filesPath = path.join(__dirname, '../fixtures/test-folder')
-    ipfs.util.addFromFs(filesPath, { recursive: true , ignore: ['files/**']}, (err, result) => {
+    ipfs.util.addFromFs(filesPath, { recursive: true, ignore: ['files/**'] }, (err, result) => {
       expect(err).to.not.exist
       expect(result.length).to.be.below(9)
       done()

--- a/test/ipfs-api/util.spec.js
+++ b/test/ipfs-api/util.spec.js
@@ -59,12 +59,22 @@ describe('.util', () => {
       done()
     })
   })
+  
+  it('.fsAdd add and ignore a directory', (done) => {
+    const filesPath = path.join(__dirname, '../fixtures/test-folder')
+    ipfs.util.addFromFs(filesPath, { recursive: true , ignore: ['files/**']}, (err, result) => {
+      expect(err).to.not.exist
+      expect(result.length).to.be.below(9)
+      done()
+    })
+  })
 
   it('.fsAdd a file', (done) => {
     const filePath = path.join(__dirname, '../fixtures/testfile.txt')
     ipfs.util.addFromFs(filePath, (err, result) => {
       expect(err).to.not.exist
-      expect(result.length).to.be.above(5)
+      expect(result.length).to.be.equal(1)
+      expect(result[0].path).to.be.equal('testfile.txt')
       done()
     })
   })


### PR DESCRIPTION
Also fixed [#408](https://github.com/ipfs/js-ipfs-api/issues/408) whilst in the area - `util.addFromFs` goes up almost to the root directory for files. It looks like for directories it was fixed in 42ccb0040b211ad302ab6e05e250e3b2024e626d, but it is now fixed for files too.

It looks like when the tests for this were written, someone expected addFromFs to go all the way up to the root dir in '.fsAdd a file' test/ipfs-api/util.spec.js- this seems like bizzare behaviour to expect, so I changed it.