### PR TITLE
Add add-from-url executable

### DIFF
--- a/bin/add-from-url
+++ b/bin/add-from-url
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+'use strict'
+
+const ipfs = require('..')()
+const [ url ] = process.argv.slice(2)
+
+if (!url) {
+  console.error('expected a url as argument')
+  process.exit(1)
+}
+
+ipfs.util.addFromURL(url)
+.then(res => res[0] && res[0].hash)
+.then(console.log)
+.catch(console.error)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "stream": "readable-stream",
     "http": "stream-http"
   },
+  "bin": {
+    "add-from-url": "./bin/add-from-url"
+  },
   "scripts": {
     "test": "gulp test",
     "test:node": "gulp test:node",


### PR DESCRIPTION
```sh
add-from-url https://example.org/whatever.jpg
# => IPFS hash
```

This command isn't available from the `ipfs` CLI but can be quite convenient and easily done from this module