### PR TITLE
Add multihashes to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "isstream": "^0.1.2",
     "lru-cache": "^4.0.2",
     "multiaddr": "^2.1.1",
+    "multihashes": "^0.3.1",
     "multipart-stream": "^2.0.1",
     "ndjson": "^1.5.0",
     "once": "^1.4.0",


### PR DESCRIPTION
Seems to have been missing since https://github.com/ipfs/js-ipfs-api/commit/43148150ec65d143481f6fab6e78bae461b8d745