### PR TITLE
Use ipfsd-ctl 0.19.0 and go-ipfs 0.4.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,12 @@ matrix:
 before_install:
   - npm install -g npm
 
-script:
+before_script:
   - npm run lint
-  - npm run test
+
+script:
+  - npm run test:node
+  - npm run test:browser
   - npm run coverage
 
 before_script:

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "gulp": "^3.9.1",
     "hapi": "^16.1.0",
     "interface-ipfs-core": "~0.24.1",
-    "ipfsd-ctl": "~0.18.2",
+    "ipfsd-ctl": "~0.19.0",
     "pre-commit": "^1.2.2",
     "socket.io": "^1.7.2",
     "socket.io-client": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "http": "stream-http"
   },
   "scripts": {
-    "test": "gulp test",
-    "test:node": "gulp test:node",
-    "test:browser": "gulp test:browser",
+    "test": "node --max_old_space_size=4096 node_modules/.bin/gulp test",
+    "test:node": "node --max_old_space_size=4096 node_modules/.bin/gulp test:node",
+    "test:browser": "node --max_old_space_size=4096 node_modules/.bin/gulp test:browser",
     "lint": "aegir-lint",
     "build": "gulp build",
     "release": "gulp release",

--- a/test/constructor.spec.js
+++ b/test/constructor.spec.js
@@ -18,15 +18,20 @@ function clientWorks (client, done) {
 
 describe('ipfs-api constructor tests', () => {
   describe('parameter permuations', () => {
-    let apiAddr
     let fc
+    let apiAddr
+    let host
+    let port
 
     before(function (done) {
       this.timeout(20 * 1000) // slow CI
       fc = new FactoryClient()
       fc.spawnNode((err, node) => {
         expect(err).to.not.exist
+        expect(node.apiAddr).to.exist
         apiAddr = node.apiAddr
+        host = apiAddr.nodeAddress().address
+        port = apiAddr.nodeAddress().port
         done()
       })
     })
@@ -34,10 +39,9 @@ describe('ipfs-api constructor tests', () => {
     after((done) => fc.dismantle(done))
 
     it('opts', (done) => {
-      const splitted = apiAddr.split('/')
       clientWorks(ipfsAPI({
-        host: splitted[2],
-        port: splitted[4],
+        host: host,
+        port: port,
         protocol: 'http'
       }), done)
     })
@@ -46,16 +50,16 @@ describe('ipfs-api constructor tests', () => {
       clientWorks(ipfsAPI(apiAddr, { protocol: 'http' }), done)
     })
 
-    it('host, port', (done) => {
-      const splitted = apiAddr.split('/')
+    it('multiaddr (string), opts', (done) => {
+      clientWorks(ipfsAPI(apiAddr.toString(), { protocol: 'http' }), done)
+    })
 
-      clientWorks(ipfsAPI(splitted[2], splitted[4]), done)
+    it('host, port', (done) => {
+      clientWorks(ipfsAPI(host, port), done)
     })
 
     it('host, port, opts', (done) => {
-      const splitted = apiAddr.split('/')
-
-      clientWorks(ipfsAPI(splitted[2], splitted[4], { protocol: 'http' }), done)
+      clientWorks(ipfsAPI(host, port, { protocol: 'http' }), done)
     })
   })
 })

--- a/test/ipfs-factory/client.js
+++ b/test/ipfs-factory/client.js
@@ -2,6 +2,7 @@
 
 const io = require('socket.io-client')
 const ipfsAPI = require('../../src')
+const Multiaddr = require('multiaddr')
 
 module.exports = Factory
 
@@ -40,8 +41,9 @@ function Factory () {
 
     function spawnNode () {
       ioC.once('fc-node', (apiAddr) => {
-        const ipfs = ipfsAPI(apiAddr)
-        ipfs.apiAddr = apiAddr
+        const addr = new Multiaddr(apiAddr)
+        const ipfs = ipfsAPI(addr)
+        ipfs.apiAddr = addr
         callback(null, ipfs)
       })
       ioC.emit('fs-spawn-node', repoPath, config)

--- a/test/ipfs-factory/server-routes.js
+++ b/test/ipfs-factory/server-routes.js
@@ -19,7 +19,7 @@ module.exports = (http) => {
       if (err) {
         throw err
       }
-      this.emit('fc-node', apiAddr)
+      this.emit('fc-node', apiAddr.toString())
     })
   }
 

--- a/test/name.spec.js
+++ b/test/name.spec.js
@@ -76,7 +76,7 @@ describe('.name', () => {
         expect(err).to.not.exist
         expect(res).to.exist
         expect(res).to.be.eql({
-          Path: '/ipfs/' + name.Value
+          Path: name.Value
         })
         done()
       })
@@ -99,7 +99,7 @@ describe('.name', () => {
         .then((res) => {
           expect(res).to.exist
           expect(res).to.be.eql({
-            Path: '/ipfs/' + name.Value
+            Path: name.Value
           })
         })
     })


### PR DESCRIPTION
This PR will comform with ipfsd-ctl@0.19.0 which changed the `.apiAddr` to be a Multiaddr instead of a string. 

We return that apiAddr from the node factory and due to `SocketIO` not handling objects and buffers successfully, we return a string. That string then gets converted back to Multiaddr in the client factory which attaches the Multiaddr to the ipfs api (like ipfsd-ctl does).

I also added a test for the constructor to accept Multiaddr both as a string and as a proper Multiaddr type.