### PR TITLE
Update ipfsd-ctl to 0.19.0 (includes go-ipfs 0.4.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "gulp": "^3.9.1",
     "hapi": "^16.1.0",
     "interface-ipfs-core": "~0.24.1",
-    "ipfsd-ctl": "~0.18.2",
+    "ipfsd-ctl": "~0.19.0",
     "pre-commit": "^1.2.2",
     "socket.io": "^1.7.2",
     "socket.io-client": "^1.7.2",


### PR DESCRIPTION
This PR will update `ipfsd-ctl` dependency to 0.19.0 which includes go-ipfs 0.4.5.

This PR is dependant on https://github.com/ipfs/js-ipfs-api/pull/525.