### PR TITLE
Links have been ignored

### DIFF
--- a/src/api/object.js
+++ b/src/api/object.js
@@ -92,6 +92,7 @@ module.exports = (send) => {
         }
       } else if (typeof obj === 'object') {
         tmpObj.Data = obj.Data.toString()
+        tmpObj.Links = obj.Links
       } else {
         return callback(new Error('obj not recognized'))
       }


### PR DESCRIPTION
If one passes a plain object (like something returned from `toJSON`), `Links` are not copied over.