### PR TITLE
Fix incorrect API path for refs.local

### DIFF
--- a/src/api/refs.js
+++ b/src/api/refs.js
@@ -26,7 +26,7 @@ module.exports = (send) => {
     }
 
     const request = {
-      path: 'refs',
+      path: 'refs/local',
       qs: opts
     }
 


### PR DESCRIPTION
Currently a call to this API point will return an empty array.