### PR TITLE
request-api allow the http method to be specified

### DIFF
--- a/src/api/block.js
+++ b/src/api/block.js
@@ -47,6 +47,7 @@ module.exports = (send) => {
       }
 
       const request = {
+        method: 'GET',
         path: 'block/get',
         args: args,
         qs: opts

--- a/src/request-api.js
+++ b/src/request-api.js
@@ -96,7 +96,7 @@ function requestAPI (config, options, callback) {
   // this option is only used internally, not passed to daemon
   delete options.qs.followSymlinks
 
-  const method = 'POST'
+  const method = options.method || 'POST'
   const headers = {}
 
   if (isNode) {


### PR DESCRIPTION
via `options.method = 'GET'`