### PR TITLE
Use CID for api.get/api.cat

### DIFF
--- a/src/api/cat.js
+++ b/src/api/cat.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const promisify = require('promisify-es6')
-const cleanMultihash = require('../clean-multihash')
+const cleanCID = require('../clean-cid')
 
 module.exports = (send) => {
   return promisify((hash, opts, callback) => {
@@ -11,7 +11,7 @@ module.exports = (send) => {
     }
 
     try {
-      hash = cleanMultihash(hash)
+      hash = cleanCID(hash)
     } catch (err) {
       return callback(err)
     }

--- a/src/api/get.js
+++ b/src/api/get.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const promisify = require('promisify-es6')
-const cleanMultihash = require('../clean-multihash')
+const cleanCID = require('../clean-cid')
 const TarStreamToObjects = require('../tar-stream-to-objects')
 
 module.exports = (send) => {
@@ -21,7 +21,7 @@ module.exports = (send) => {
     }
 
     try {
-      path = cleanMultihash(path)
+      path = cleanCID(path)
     } catch (err) {
       return callback(err)
     }

--- a/src/clean-cid.js
+++ b/src/clean-cid.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const bs58 = require('bs58')
+const CID = require('cids')
+
+module.exports = function (cid) {
+  if (Buffer.isBuffer(cid)) {
+    cid = bs58.encode(cid)
+  }
+  if (typeof cid !== 'string') {
+    throw new Error('unexpected cid type: ' + typeof cid)
+  }
+  CID.validateCID(new CID(cid.split('/')[0]))
+  return cid
+}


### PR DESCRIPTION
go-ipfs supports CIDv1 for cat/get commands, so I guess it should also be supported here.

https://github.com/ipfs/interface-ipfs-core/tree/master/API/files#cat should be updated if this gets merged.