### PR TITLE
make ipfs add --nocopy works

### DIFF
--- a/src/get-files-stream.js
+++ b/src/get-files-stream.js
@@ -16,6 +16,7 @@ function headers (file) {
   } else if (file.symlink) {
     header['Content-Type'] = 'application/symlink'
   } else {
+    header['Abspath'] = file.absPath
     header['Content-Type'] = 'application/octet-stream'
   }
 
@@ -69,6 +70,7 @@ function loadPaths (opts, file) {
         // files
         if (mg.cache[name] === 'FILE') {
           return {
+            absPath: name,
             path: strip(name, file),
             symlink: false,
             dir: false,
@@ -91,6 +93,7 @@ function loadPaths (opts, file) {
   }
 
   return {
+    absPath: file,
     path: path.basename(file),
     content: fs.createReadStream(file)
   }
@@ -122,6 +125,7 @@ function getFilesStream (files, opts) {
     }
 
     return {
+      absPath: '',
       path: '',
       symlink: false,
       dir: false,


### PR DESCRIPTION
Related to https://github.com/ipfs/js-ipfs-api/issues/562

Provide the Abspath header in the stream for files so the filestore can find the actual file on disk.
It works but I still get errors like 'Error: expected protobuf dag node' for some files but not for some others.

@kevina, any ideas ?