### PR TITLE
Allow options with ipfs.add

### DIFF
--- a/src/api/add.js
+++ b/src/api/add.js
@@ -5,7 +5,12 @@ const promisify = require('promisify-es6')
 const DAGNodeStream = require('../dagnode-stream')
 
 module.exports = (send) => {
-  return promisify((files, callback) => {
+  return promisify((files, opts, callback) => {
+    if (typeof (opts) === 'function') {
+      callback = opts
+      opts = {}
+    }
+
     const ok = Buffer.isBuffer(files) ||
                isStream.isReadable(files) ||
                Array.isArray(files)
@@ -14,7 +19,7 @@ module.exports = (send) => {
       return callback(new Error('"files" must be a buffer, readable stream, or array of objects'))
     }
 
-    const request = { path: 'add', files: files }
+    const request = { path: 'add', files: files, qs: opts }
 
     // Transform the response stream to DAGNode values
     const transform = (res, callback) => DAGNodeStream.streamToValue(send, res, callback)

--- a/test/files.spec.js
+++ b/test/files.spec.js
@@ -15,6 +15,8 @@ const testfile = isNode
   ? loadFixture(__dirname, '/fixtures/testfile.txt')
   : loadFixture(__dirname, 'fixtures/testfile.txt')
 
+const expectedMultihash = 'Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP'
+
 describe('.files (the MFS API part)', () => {
   let ipfs
   let fc
@@ -32,10 +34,19 @@ describe('.files (the MFS API part)', () => {
   after((done) => fc.dismantle(done))
 
   describe('Callback API', () => {
-    it('add file for testing', (done) => {
-      const expectedMultihash = 'Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP'
-
+    it('files.add', (done) => {
       ipfs.files.add(testfile, (err, res) => {
+        expect(err).to.not.exist()
+
+        expect(res).to.have.length(1)
+        expect(res[0].hash).to.equal(expectedMultihash)
+        expect(res[0].path).to.equal(expectedMultihash)
+        done()
+      })
+    })
+
+    it('files.add with options', (done) => {
+      ipfs.files.add(testfile, { pin: false }, (err, res) => {
         expect(err).to.not.exist()
 
         expect(res).to.have.length(1)
@@ -170,6 +181,24 @@ describe('.files (the MFS API part)', () => {
   })
 
   describe('Promise API', () => {
+    it('files.add', () => {
+      return ipfs.files.add(testfile)
+      .then((res) => {
+        expect(res).to.have.length(1)
+        expect(res[0].hash).to.equal(expectedMultihash)
+        expect(res[0].path).to.equal(expectedMultihash)
+      })
+    })
+
+    it('files.add with options', () => {
+      return ipfs.files.add(testfile, { pin: false })
+      .then((res) => {
+        expect(res).to.have.length(1)
+        expect(res[0].hash).to.equal(expectedMultihash)
+        expect(res[0].path).to.equal(expectedMultihash)
+      })
+    })
+
     it('files.mkdir', () => {
       return ipfs.files.mkdir('/test-folder')
     })


### PR DESCRIPTION
Hey folks,

Great project! Thought I would update `ipfs.add` and `ipfs.files.add` to accept options, following the [function signature in your docs](https://github.com/ipfs/interface-ipfs-core/tree/master/API/files#javascript---ipfsfilesadddata-options-callback):

`ipfs.files.add(data, [options], [callback])`

and the cli:

```sh
ipfs add [--recursive | -r] [--quiet | -q] [--quieter | -Q] [--silent] [--progress | -p] [--trickle | -t] [--only-hash | -n] [--wrap-with-directory | -w] [--hidden | -H] [--chunker=<chunker> | -s] [--pin=false] [--raw-leaves] [--nocopy] [--fscache] [--cid-version=<cid-version>] [--] <path>...
```