### PR TITLE
Feat/dag api

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "glob-escape": "0.0.2",
     "ipfs-block": "~0.5.5",
     "ipfs-unixfs": "~0.1.10",
+    "ipld-dag-cbor": "^0.11.1",
     "ipld-dag-pb": "~0.9.5",
     "is-ipfs": "~0.3.0",
     "isstream": "^0.1.2",

--- a/src/api/dag.js
+++ b/src/api/dag.js
@@ -71,7 +71,40 @@ module.exports = (send) => {
       }
     }),
     get: promisify((cid, path, options, callback) => {
-      // TODO
+      if (typeof path === 'function') {
+        callback = path
+        path = undefined
+      }
+
+      if (typeof options === 'function') {
+        callback = options
+        options = {}
+      }
+
+      options = options || {}
+
+      if (typeof cid === 'string') {
+        const split = cid.split('/')
+        cid = split[0]
+        split.shift()
+
+        if (split.length > 0) {
+          path = split.join('/')
+        } else {
+          path = '/'
+        }
+      }
+
+      send({
+        path: 'dag/get',
+        args: cid + path,
+        qs: options
+      }, (err, result) => {
+        if (err) {
+          return callback(err)
+        }
+        callback(undefined, {value: result})
+      })
     })
   }
 

--- a/src/api/dag.js
+++ b/src/api/dag.js
@@ -66,7 +66,11 @@ module.exports = (send) => {
           if (err) {
             return callback(err)
           }
-          // TODO handle the result
+          if (result.Cid) {
+            return callback(null, new CID(result.Cid['/']))
+          } else {
+            return callback(result)
+          }
         })
       }
     }),
@@ -83,6 +87,10 @@ module.exports = (send) => {
 
       options = options || {}
 
+      if (CID.isCID(cid)) {
+        cid = cid.toBaseEncodedString()
+      }
+
       if (typeof cid === 'string') {
         const split = cid.split('/')
         cid = split[0]
@@ -97,7 +105,7 @@ module.exports = (send) => {
 
       send({
         path: 'dag/get',
-        args: cid + path,
+        args: cid + '/' + path,
         qs: options
       }, (err, result) => {
         if (err) {


### PR DESCRIPTION
Improving previous work on DAG API. (https://github.com/ipfs/js-ipfs-api/pull/534/)

- add @magik6k DAG Get implementation
- Handle dag put response
- enable CIDs as dag get parameters
- fix DAG Get requet param formation

See also https://github.com/atfornes/js-ipfs-api/withDag for a working DAG API with `json` input encoding (which is equivalent as using dag-cbor without Buffers)