### PR TITLE
object patch add-link: don't force to have a Buffer for 'ref'

### DIFF
--- a/src/object/addLink.js
+++ b/src/object/addLink.js
@@ -27,7 +27,7 @@ module.exports = (send) => {
       args: [
         multihash,
         dLink.name,
-        bs58.encode(dLink.multihash).toString()
+        cleanMultihash(dLink.multihash)
       ]
     }, (err, result) => {
       if (err) {

--- a/src/object/addLink.js
+++ b/src/object/addLink.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const promisify = require('promisify-es6')
-const bs58 = require('bs58')
 const cleanMultihash = require('../utils/clean-multihash')
 
 module.exports = (send) => {


### PR DESCRIPTION
This allows to send a multi-hash as a string as well.