### PR TITLE
Adds wiring for a progress bar

### DIFF
--- a/src/files/add.js
+++ b/src/files/add.js
@@ -21,10 +21,11 @@ module.exports = (send) => {
       return callback(new Error('"files" must be a buffer, readable stream, or array of objects'))
     }
 
-    const request = { path: 'add', files: files, qs: opts }
+    const request = { path: 'add', files: files, qs: opts, progress: opts.progress }
 
     // Transform the response stream to DAGNode values
     const transform = (res, callback) => DAGNodeStream.streamToValue(send, res, callback)
+
     send.andTransform(request, transform, callback)
   })
 }

--- a/test/files.spec.js
+++ b/test/files.spec.js
@@ -73,6 +73,15 @@ describe('.files (the MFS API part)', function () {
       })
     })
 
+    it.only('files.add with progress options', (done) => {
+      ipfs.files.add(testfile, {progress: false}, (err, res) => {
+        expect(err).to.not.exist()
+
+        expect(res).to.have.length(1)
+        done()
+      })
+    })
+
     it('files.mkdir', (done) => {
       ipfs.files.mkdir('/test-folder', done)
     })


### PR DESCRIPTION
Passes the 'progress bar' option for transfers over `ipfs-api` (http). Progress is shown for your payload being streamed up to the server.

There is a pause.

Then you get your response (list of files).

![progress-ipfs-api-folder](https://user-images.githubusercontent.com/4499581/30120651-67c3463c-9321-11e7-88b8-36616fa17fc7.gif)

This example shows a folder of movie clips being added via `ipfs-api` with the daemon running.