### PR TITLE
Support specify hash algorithm in files.add

### DIFF
--- a/src/files/add.js
+++ b/src/files/add.js
@@ -30,7 +30,7 @@ module.exports = (send) => {
     }
 
     if (opts['raw-leaves'] != null) {
-      qs['raw-leaves'] = opts['raw-version']
+      qs['raw-leaves'] = opts['raw-leaves']
     } else if (opts.rawLeaves != null) {
       qs['raw-leaves'] = opts.rawLeaves
     }

--- a/src/files/add.js
+++ b/src/files/add.js
@@ -21,7 +21,27 @@ module.exports = (send) => {
       return callback(new Error('"files" must be a buffer, readable stream, or array of objects'))
     }
 
-    const request = { path: 'add', files: files, qs: opts }
+    const qs = {}
+
+    if (opts['cid-version'] != null) {
+      qs['cid-version'] = opts['cid-version']
+    } else if (opts.cidVersion != null) {
+      qs['cid-version'] = opts.cidVersion
+    }
+
+    if (opts['raw-leaves'] != null) {
+      qs['raw-leaves'] = opts['raw-version']
+    } else if (opts.rawLeaves != null) {
+      qs['raw-leaves'] = opts.rawLeaves
+    }
+
+    if (opts.hash != null) {
+      qs.hash = opts.hash
+    } else if (opts.hashAlg != null) {
+      qs.hash = opts.hashAlg
+    }
+
+    const request = { path: 'add', files: files, qs: qs }
 
     // Transform the response stream to DAGNode values
     const transform = (res, callback) => DAGNodeStream.streamToValue(send, res, callback)

--- a/src/object/data.js
+++ b/src/object/data.js
@@ -11,7 +11,7 @@ const lruOptions = {
 const cache = LRU(lruOptions)
 
 module.exports = (send) => {
-  return promisify((hash, options, callback) => {
+  return promisify((cid, options, callback) => {
     if (typeof options === 'function') {
       callback = options
       options = {}
@@ -20,16 +20,16 @@ module.exports = (send) => {
       options = {}
     }
 
-    let cid, b58Hash
+    let cidB58Str
 
     try {
-      cid = new CID(hash)
-      b58Hash = cid.toBaseEncodedString()
+      cid = new CID(cid)
+      cidB58Str = cid.toBaseEncodedString()
     } catch (err) {
       return callback(err)
     }
 
-    const node = cache.get(b58Hash)
+    const node = cache.get(cidB58Str)
 
     if (node) {
       return callback(null, node.data)
@@ -37,7 +37,7 @@ module.exports = (send) => {
 
     send({
       path: 'object/data',
-      args: b58Hash
+      args: cidB58Str
     }, (err, result) => {
       if (err) {
         return callback(err)

--- a/src/object/get.js
+++ b/src/object/get.js
@@ -5,7 +5,7 @@ const dagPB = require('ipld-dag-pb')
 const DAGNode = dagPB.DAGNode
 const DAGLink = dagPB.DAGLink
 const bs58 = require('bs58')
-const cleanMultihash = require('../utils/clean-multihash')
+const CID = require('cids')
 const LRU = require('lru-cache')
 const lruOptions = {
   max: 128
@@ -14,7 +14,7 @@ const lruOptions = {
 const cache = LRU(lruOptions)
 
 module.exports = (send) => {
-  return promisify((multihash, options, callback) => {
+  return promisify((hash, options, callback) => {
     if (typeof options === 'function') {
       callback = options
       options = {}
@@ -24,13 +24,16 @@ module.exports = (send) => {
       options = {}
     }
 
+    let cid, b58Hash
+
     try {
-      multihash = cleanMultihash(multihash, options)
+      cid = new CID(hash)
+      b58Hash = cid.toBaseEncodedString()
     } catch (err) {
       return callback(err)
     }
 
-    const node = cache.get(multihash)
+    const node = cache.get(b58Hash)
 
     if (node) {
       return callback(null, node)
@@ -38,7 +41,7 @@ module.exports = (send) => {
 
     send({
       path: 'object/get',
-      args: multihash
+      args: b58Hash
     }, (err, result) => {
       if (err) {
         return callback(err)
@@ -52,7 +55,7 @@ module.exports = (send) => {
         if (err) {
           return callback(err)
         }
-        cache.set(multihash, node)
+        cache.set(b58Hash, node)
         callback(null, node)
       })
     })

--- a/src/object/get.js
+++ b/src/object/get.js
@@ -14,7 +14,7 @@ const lruOptions = {
 const cache = LRU(lruOptions)
 
 module.exports = (send) => {
-  return promisify((hash, options, callback) => {
+  return promisify((cid, options, callback) => {
     if (typeof options === 'function') {
       callback = options
       options = {}
@@ -24,16 +24,16 @@ module.exports = (send) => {
       options = {}
     }
 
-    let cid, b58Hash
+    let cidB58Str
 
     try {
-      cid = new CID(hash)
-      b58Hash = cid.toBaseEncodedString()
+      cid = new CID(cid)
+      cidB58Str = cid.toBaseEncodedString()
     } catch (err) {
       return callback(err)
     }
 
-    const node = cache.get(b58Hash)
+    const node = cache.get(cidB58Str)
 
     if (node) {
       return callback(null, node)
@@ -41,7 +41,7 @@ module.exports = (send) => {
 
     send({
       path: 'object/get',
-      args: b58Hash
+      args: cidB58Str
     }, (err, result) => {
       if (err) {
         return callback(err)
@@ -55,7 +55,7 @@ module.exports = (send) => {
         if (err) {
           return callback(err)
         }
-        cache.set(b58Hash, node)
+        cache.set(cidB58Str, node)
         callback(null, node)
       })
     })

--- a/src/utils/get-dagnode.js
+++ b/src/utils/get-dagnode.js
@@ -2,22 +2,16 @@
 
 const DAGNode = require('ipld-dag-pb').DAGNode
 const parallel = require('async/parallel')
-const CID = require('cids')
-const mh = require('multihashes')
 const streamToValue = require('./stream-to-value')
 
 module.exports = function (send, hash, callback) {
-  // Until js-ipfs supports object/get and object/data by CID
-  // we need to convert our CID or multihash hash into a multihash
-  const multihash = mh.toB58String(new CID(hash).multihash)
-
   // Retrieve the object and its data in parallel, then produce a DAGNode
   // instance using this information.
   parallel([
     (done) => {
       send({
         path: 'object/get',
-        args: multihash
+        args: hash
       }, done)
     },
     (done) => {
@@ -26,7 +20,7 @@ module.exports = function (send, hash, callback) {
       // See https://github.com/ipfs/go-ipfs/issues/1582 for more details.
       send({
         path: 'object/data',
-        args: multihash
+        args: hash
       }, done)
     }
   ], (err, res) => {


### PR DESCRIPTION
### Specify multihash hashing alogrithm

This allows the optional param `hash` or `hashAlg` to be passed to `files.add` in order to specify the hash algorithm that should be used when generating the multihash(es) for the added content.

This PR also is more strict about what query string options `js-ipfs-api` supports by pulling out the supported params into a new query string object.

It also allows camel case aliases for params that are dash separated. This is because the HTTP API uses dash separated param names, but it is far easier to use camel case param names for internal APIs.

The other reason for allowing these aliases is because this code may be called when talking to a remote IPFS instance via the CLI where the qs params will have already been converted into camelCase.

### Change `object/get` and `object/data` to accept CIDs

This is necessary because `get-dagnode.js` uses `object/get` and `object/data` immediately after adding files. When specifying `--cid-version` or using `--hash` (which has the effect of setting `--cidversion=true`) `get-dagnode.js` is passed a CIDv1 not a multihash/CIDv0.

**Previously `get-dagnode.js` was extracting a multihash from a CID and sending that, effectively downgrading a CIDv1 to a CIDv0**.

That causes the object to not be found (see https://github.com/ipfs/js-ipfs-unixfs-engine/pull/185) since you have to retrieve using the same CID version as the data was stored.

This actually brings js-ipfs more in line with go-ipfs. Where both `object/get` and `object/data` accept a CID:

```sh
# With go ipfs daemon running...
$ ipfs add test.txt --cid-version=1 --raw-leaves=false
added zdj7WdDqrSLbsDNdtsHU5eWAeBukPoKfX9doKuTAphCowKjZR test.txt
$ ipfs object get zdj7WdDqrSLbsDNdtsHU5eWAeBukPoKfX9doKuTAphCowKjZR
{"Links":[],"Data":"\u0008\u0002\u0012\u001f(╯°□°）╯︵ ┻━┻\n\u0018\u001f"}
$ ipfs object data zdj7WdDqrSLbsDNdtsHU5eWAeBukPoKfX9doKuTAphCowKjZR
(╯°□°）╯︵ ┻━┻
```