### PR TITLE
Make pin interface respect interface-ipfs-core API

### DIFF
--- a/src/pin/add.js
+++ b/src/pin/add.js
@@ -16,7 +16,7 @@ module.exports = (send) => {
       if (err) {
         return callback(err)
       }
-      callback(null, res.Pins)
+      callback(null, res.Pins.map(hash => ({ hash })))
     })
   })
 }

--- a/src/pin/ls.js
+++ b/src/pin/ls.js
@@ -1,23 +1,23 @@
 'use strict'
 
 const promisify = require('promisify-es6')
+const _ = require('lodash')
 
 module.exports = (send) => {
   return promisify((hash, opts, callback) => {
-    if (typeof opts === 'function') {
-      callback = opts
-      opts = {}
-    }
-
-    if (typeof hash === 'object') {
-      opts = hash
-      hash = undefined
-    }
-
     if (typeof hash === 'function') {
       callback = hash
-      hash = undefined
-      opts = {}
+      opts = null
+      hash = null
+    }
+    if (typeof opts === 'function') {
+      callback = opts
+    }
+    if (hash && hash.type) {
+      opts = hash
+      hash = null
+    } else {
+      opts = null
     }
 
     send({
@@ -28,7 +28,9 @@ module.exports = (send) => {
       if (err) {
         return callback(err)
       }
-      callback(null, res.Keys)
+      callback(null, _.keys(res.Keys).map(hash => (
+        { hash, type: res.Keys[hash].Type }
+      )))
     })
   })
 }

--- a/src/pin/rm.js
+++ b/src/pin/rm.js
@@ -16,7 +16,7 @@ module.exports = (send) => {
       if (err) {
         return callback(err)
       }
-      callback(null, res.Pins)
+      callback(null, res.Pins.map(hash => ({ hash })))
     })
   })
 }


### PR DESCRIPTION
As per discussion [here](https://github.com/ipfs/js-ipfs/pull/107#issuecomment-329704097), the pin methods should return results consistent with the [interface-ipfs-core API](https://github.com/ipfs/interface-ipfs-core/tree/master/API/pin).