### PR TITLE
pass the config protocol to http requests

### DIFF
--- a/src/utils/request-api.js
+++ b/src/utils/request-api.js
@@ -152,7 +152,8 @@ function requestAPI (config, options, callback) {
     path: `${config['api-path']}${options.path}?${qs}`,
     port: config.port,
     method: method,
-    headers: headers
+    headers: headers,
+    protocol: `${config.protocol}:`
   }, onRes(options.buffer, callback))
 
   req.on('error', (err) => {


### PR DESCRIPTION

While calling `request(config.protocol)` sets the right http protocol api to use it does not correctly pass the protocol information to node_modules/stream-http.

If the page is loaded over https and the daemon is located on http it fails to send the api request to the deamon.

This is because the code believes the daemon is located at https://127.0.0.1:5001/<insert api string here> when it is actually located at http://127.0.0.1:5001/<insert api string here>. 

Without this change the code throws an unrecoverable error and doesnt provide the user with information to fix the issue, with the change it still throws an error but it also lets the user resolve the issue by clicking the mixed content shield ![shield image](https://i.imgur.com/2kfXXGK.png) and allowing insecure content.