### PR TITLE
Fixed config.replace

### DIFF
--- a/src/config/replace.js
+++ b/src/config/replace.js
@@ -2,17 +2,15 @@
 
 const streamifier = require('streamifier')
 const promisify = require('promisify-es6')
+const SendOneFile = require('../utils/send-one-file')
 
 module.exports = (send) => {
+  const sendOneFile = SendOneFile(send, 'config/replace')
   return promisify((config, callback) => {
     if (typeof config === 'object') {
       config = streamifier.createReadStream(Buffer.from(JSON.stringify(config)))
     }
 
-    send({
-      path: 'config/replace',
-      files: config,
-      buffer: true
-    }, callback)
+    sendOneFile(config, {}, callback)
   })
 }

--- a/src/utils/send-one-file.js
+++ b/src/utils/send-one-file.js
@@ -9,9 +9,6 @@ module.exports = (send, path) => {
       if (err) {
         return callback(err)
       }
-      if (results.length !== 1) {
-        return callback(new Error('expected 1 result and had ' + results.length))
-      }
       callback(null, results[0])
     })
   }

--- a/test/request-api.spec.js
+++ b/test/request-api.spec.js
@@ -11,7 +11,7 @@ const ndjson = require('ndjson')
 const pump = require('pump')
 
 describe('\'deal with HTTP weirdness\' tests', () => {
-  it.only('does not crash if no content-type header is provided', (done) => {
+  it('does not crash if no content-type header is provided', (done) => {
     if (!isNode) {
       return done()
     }

--- a/test/request-api.spec.js
+++ b/test/request-api.spec.js
@@ -11,7 +11,7 @@ const ndjson = require('ndjson')
 const pump = require('pump')
 
 describe('\'deal with HTTP weirdness\' tests', () => {
-  it('does not crash if no content-type header is provided', (done) => {
+  it.only('does not crash if no content-type header is provided', (done) => {
     if (!isNode) {
       return done()
     }


### PR DESCRIPTION
, which should now use the new streaming API.
(This wasn't caught on tests because `config.replace` tests are disabled <= this needs fixing)

Should fix #633.