### PR TITLE
fix(files.add): handle weird directory names

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "detect-node": "^2.0.3",
     "flatmap": "0.0.3",
     "glob": "^7.1.2",
-    "glob-escape": "0.0.2",
     "ipfs-block": "~0.6.1",
     "ipfs-unixfs": "~0.1.14",
     "ipld-dag-pb": "~0.11.3",


### PR DESCRIPTION
`glob` is interpreting the '[' in `weird [v0]` as a special magic character.  According to its documentation, a caller should be able to escape it with `\`; but it does not work. See the [glob issue](https://github.com/isaacs/node-glob/issues/277).

Should fix [a directory with an odd name](https://github.com/ipfs/js-ipfs-api/pull/644).