### PR TITLE
test: HTTP weirdness

### DIFF
--- a/test/request-api.spec.js
+++ b/test/request-api.spec.js
@@ -24,7 +24,8 @@ describe('\'deal with HTTP weirdness\' tests', () => {
     })
 
     server.listen(6001, () => {
-      ipfsAPI('/ip4/127.0.0.1/tcp/6001').config.replace('test/fixtures/r-config.json', (err) => {
+//      ipfsAPI('/ip4/127.0.0.1/tcp/6001').config.replace('test/fixtures/r-config.json', (err) => {
+      ipfsAPI('/ip4/127.0.0.1/tcp/6001').id((err) => {
         expect(err).to.not.exist()
         server.close(done)
       })

--- a/test/request-api.spec.js
+++ b/test/request-api.spec.js
@@ -19,13 +19,16 @@ describe('\'deal with HTTP weirdness\' tests', () => {
     // go-ipfs always (currently) adds a content-type header, even if no content is present,
     // the standard behaviour for an http-api is to omit this header if no content is present
     const server = require('http').createServer((req, res) => {
-      res.writeHead(200)
-      res.end()
+      // Consume the entire request, before responding.
+      req.on('data', () => {})
+      req.on('end', () => {
+        res.writeHead(200)
+        res.end()
+      })
     })
 
     server.listen(6001, () => {
-//      ipfsAPI('/ip4/127.0.0.1/tcp/6001').config.replace('test/fixtures/r-config.json', (err) => {
-      ipfsAPI('/ip4/127.0.0.1/tcp/6001').id((err) => {
+      ipfsAPI('/ip4/127.0.0.1/tcp/6001').config.replace('test/fixtures/r-config.json', (err) => {
         expect(err).to.not.exist()
         server.close(done)
       })


### PR DESCRIPTION
First reported in https://github.com/ipfs/js-ipfs-api/pull/648
```
4) 'deal with HTTP weirdness' tests does not crash if no content-type header is provided:
     Uncaught AssertionError: expected [Error: read ECONNRESET] to not exist 
      at ipfsAPI.config.replace (test\request-api.spec.js:28:28)
```

This is just a work around and does not fix the underlying problem.  I've changed the test to use `id` instead of `config.replace` and the test passes.

@diasdavid I'm think the `ECONNRESET` could be coming from push stream not being read by the server.  But perhaps it something else.  More eyeballs might help.  I think it's more of a timing/race issue than a specific windows issue

