### PR TITLE
Fix empty path error

### DIFF
--- a/src/utils/prepare-file.js
+++ b/src/utils/prepare-file.js
@@ -90,7 +90,7 @@ function prepareFile (file, opts) {
       return file
     }
 
-    if (file.path && (file.content || file.dir)) {
+    if (file.content || file.dir) {
       return file
     }
 

--- a/test/files.spec.js
+++ b/test/files.spec.js
@@ -62,7 +62,7 @@ describe('.files (the MFS API part)', function () {
       })
     })
 
-    it.only('files.add with empty path and buffer content', (done) => {
+    it('files.add with empty path and buffer content', (done) => {
       const expectedHash = 'QmWfVY9y3xjsixTgbd9AorQxH7VtMpzfx2HaWtsoUYecaX'
       const content = Buffer.from('hello')
 

--- a/test/files.spec.js
+++ b/test/files.spec.js
@@ -62,6 +62,20 @@ describe('.files (the MFS API part)', function () {
       })
     })
 
+    it.only('files.add with empty path and buffer content', (done) => {
+      const expectedHash = 'QmWfVY9y3xjsixTgbd9AorQxH7VtMpzfx2HaWtsoUYecaX'
+      const content = Buffer.from('hello')
+
+      ipfs.files.add([{ path: '', content }], (err, res) => {
+        expect(err).to.not.exist()
+
+        expect(res).to.have.length(1)
+        expect(res[0].hash).to.equal(expectedHash)
+        expect(res[0].path).to.equal(expectedHash)
+        done()
+      })
+    })
+
     it('files.add with cid-version=1 and raw-leaves=false', (done) => {
       const expectedCid = 'zdj7Wh9x6gXdg4UAqhRYnjBTw9eJF7hvzUU4HjpnZXHYQz9jK'
       const options = { 'cid-version': 1, 'raw-leaves': false }


### PR DESCRIPTION
Prior to this PR, `ipfs.files.add([{ path: '', content: Buffer.from('TEST') }])` made error:

```
TypeError: content.once is not a function
    at Multipart._pushFile (/Users/alan/Code/protocol-labs/js-ipfs-api/src/utils/multipart.js:80:13)
    at Multipart._maybeDrain (/Users/alan/Code/protocol-labs/js-ipfs-api/src/utils/multipart.js:48:14)
    at Multipart._transform (/Users/alan/Code/protocol-labs/js-ipfs-api/src/utils/multipart.js:40:10)
    at Multipart.Transform._read (_stream_transform.js:185:10)
    at Multipart.Transform._write (_stream_transform.js:173:12)
    at doWrite (_stream_writable.js:399:12)
    at writeOrBuffer (_stream_writable.js:385:5)
    at Multipart.Writable.write (_stream_writable.js:292:11)
    at eachSeries (/Users/alan/Code/protocol-labs/js-ipfs-api/src/utils/send-files-stream.js:52:35)
    at /Users/alan/Code/protocol-labs/js-ipfs-api/node_modules/async/internal/withoutIndex.js:9:16
    at replenish (/Users/alan/Code/protocol-labs/js-ipfs-api/node_modules/async/internal/eachOfLimit.js:64:17)
    at /Users/alan/Code/protocol-labs/js-ipfs-api/node_modules/async/internal/eachOfLimit.js:68:9
    at eachLimit (/Users/alan/Code/protocol-labs/js-ipfs-api/node_modules/async/eachLimit.js:43:36)
    at /Users/alan/Code/protocol-labs/js-ipfs-api/node_modules/async/internal/doLimit.js:9:16
    at Duplex.retStream._write (/Users/alan/Code/protocol-labs/js-ipfs-api/src/utils/send-files-stream.js:50:9)
    at doWrite (_stream_writable.js:399:12)
    at writeOrBuffer (_stream_writable.js:385:5)
    at Duplex.Writable.write (_stream_writable.js:292:11)
    at files.forEach (/Users/alan/Code/protocol-labs/js-ipfs-api/src/files/add.js:39:36)
    at Array.forEach (<anonymous>)
    at Function.promisify (/Users/alan/Code/protocol-labs/js-ipfs-api/src/files/add.js:39:11)
    at Object.add (/Users/alan/Code/protocol-labs/js-ipfs-api/node_modules/promisify-es6/index.js:32:27)
    at Context.it.only (/Users/alan/Code/protocol-labs/js-ipfs-api/test/files.spec.js:69:18)
    at callFnAsync (/Users/alan/Code/protocol-labs/js-ipfs-api/node_modules/mocha/lib/runnable.js:377:21)
    at Test.Runnable.run (/Users/alan/Code/protocol-labs/js-ipfs-api/node_modules/mocha/lib/runnable.js:324:7)
    at Runner.runTest (/Users/alan/Code/protocol-labs/js-ipfs-api/node_modules/mocha/lib/runner.js:442:10)
    at /Users/alan/Code/protocol-labs/js-ipfs-api/node_modules/mocha/lib/runner.js:560:12
    at next (/Users/alan/Code/protocol-labs/js-ipfs-api/node_modules/mocha/lib/runner.js:356:14)
    at /Users/alan/Code/protocol-labs/js-ipfs-api/node_modules/mocha/lib/runner.js:366:7
    at next (/Users/alan/Code/protocol-labs/js-ipfs-api/node_modules/mocha/lib/runner.js:290:14)
    at Immediate._onImmediate (/Users/alan/Code/protocol-labs/js-ipfs-api/node_modules/mocha/lib/runner.js:334:5)
    at runCallback (timers.js:773:18)
    at tryOnImmediate (timers.js:734:5)
    at processImmediate [as _immediateCallback] (timers.js:711:5)
```

This is legal in `js-ipfs` - in fact, [normalizeContent](https://github.com/ipfs/js-ipfs/blob/624cb47d1c3becca1001f79c7e8fdc8bfcd43480/src/core/components/files.js#L44-L72) turns your buffers into objects with `path: ''` anyway, so this PR alters `js-ipfs-api` to allow this.

I think this is related to #649 but it's a slightly different issue.