### PR TITLE
chore: update dependency: pump version 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "promisify-es6": "^1.0.3",
     "pull-defer": "^0.2.2",
     "pull-pushable": "^2.1.2",
-    "pump": "^1.0.3",
+    "pump": "^2.0.0",
     "qs": "^6.5.1",
     "readable-stream": "^2.3.3",
     "stream-http": "^2.7.2",

--- a/src/log/tail.js
+++ b/src/log/tail.js
@@ -12,7 +12,8 @@ module.exports = (send) => {
       if (err) {
         return callback(err)
       }
-      const outputStream = pump(response, ndjson.parse())
+      const outputStream = ndjson.parse()
+      pump(response, outputStream)
       callback(null, outputStream)
     })
   })

--- a/src/utils/converter.js
+++ b/src/utils/converter.js
@@ -44,9 +44,10 @@ class ConverterStream extends TransformStream {
 }
 
 function converter (inputStream, callback) {
-  const outputStream = pump(
+  const outputStream = new ConverterStream()
+  pump(
     inputStream,
-    new ConverterStream(),
+    outputStream,
     (err) => {
       if (err) {
         callback(err)

--- a/src/utils/send-request.js
+++ b/src/utils/send-request.js
@@ -46,7 +46,8 @@ function onRes (buffer, cb) {
 
     // Return a stream of JSON objects
     if (chunkedObjects && isJson) {
-      const outputStream = pump(res, ndjson.parse())
+      const outputStream = ndjson.parse()
+      pump(res, outputStream)
       res.on('end', () => {
         let err = res.trailers['x-stream-error']
         if (err) {


### PR DESCRIPTION
Bumps pump to version 2.0.

One nasty surprise:

Version 2.0 of pump does not return the last stream, which means that stuff like:

```
return pump(s1, s2)
```

does not work any more.

Track issue / feature request here: https://github.com/mafintosh/pump/issues/27