### PR TITLE
breaking change: normalize fields and flatten output

### DIFF
--- a/src/files/ls.js
+++ b/src/files/ls.js
@@ -2,16 +2,27 @@
 
 const promisify = require('promisify-es6')
 
+const transform = function (res, callback) {
+  callback(null, res.Entries.map((entry) => {
+    return {
+      name: entry.Name,
+      type: entry.Type,
+      size: entry.Size,
+      hash: entry.Hash
+    }
+  }))
+}
+
 module.exports = (send) => {
   return promisify((args, opts, callback) => {
     if (typeof (opts) === 'function') {
       callback = opts
       opts = {}
     }
-    return send({
+    return send.andTransform({
       path: 'files/ls',
       args: args,
       qs: opts
-    }, callback)
+    }, transform, callback)
   })
 }

--- a/src/files/stat.js
+++ b/src/files/stat.js
@@ -2,16 +2,26 @@
 
 const promisify = require('promisify-es6')
 
+const transform = function (res, callback) {
+  callback(null, {
+    type: res.Type,
+    blocks: res.Blocks,
+    size: res.Size,
+    hash: res.Hash,
+    cumulativeSize: res.CumulativeSize
+  })
+}
+
 module.exports = (send) => {
   return promisify((args, opts, callback) => {
     if (typeof (opts) === 'function') {
       callback = opts
       opts = {}
     }
-    send({
+    send.andTransform({
       path: 'files/stat',
       args: args,
       qs: opts
-    }, callback)
+    }, transform, callback)
   })
 }

--- a/test/files.spec.js
+++ b/test/files.spec.js
@@ -231,7 +231,7 @@ describe('.files (the MFS API part)', function () {
     it('files.ls', (done) => {
       ipfs.files.ls('/test-folder', (err, res) => {
         expect(err).to.not.exist()
-        expect(res.Entries.length).to.equal(1)
+        expect(res.length).to.equal(1)
         done()
       })
     })
@@ -286,11 +286,11 @@ describe('.files (the MFS API part)', function () {
       ipfs.files.stat('/test-folder/test-file', (err, res) => {
         expect(err).to.not.exist()
         expect(res).to.deep.equal({
-          Hash: 'Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP',
-          Size: 12,
-          CumulativeSize: 20,
-          Blocks: 0,
-          Type: 'file'
+          hash: 'Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP',
+          size: 12,
+          cumulativeSize: 20,
+          blocks: 0,
+          type: 'file'
         })
 
         done()
@@ -404,7 +404,7 @@ describe('.files (the MFS API part)', function () {
     it('files.ls', () => {
       return ipfs.files.ls('/test-folder')
         .then((res) => {
-          expect(res.Entries.length).to.equal(1)
+          expect(res.length).to.equal(1)
         })
     })
 

--- a/test/files.spec.js
+++ b/test/files.spec.js
@@ -458,11 +458,11 @@ describe('.files (the MFS API part)', function () {
       return ipfs.files.stat('/test-folder/test-file')
         .then((res) => {
           expect(res).to.deep.equal({
-            Hash: 'Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP',
-            Size: 12,
-            CumulativeSize: 20,
-            Blocks: 0,
-            Type: 'file'
+            hash: 'Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP',
+            size: 12,
+            cumulativeSize: 20,
+            blocks: 0,
+            type: 'file'
           })
         })
     })


### PR DESCRIPTION
This normalizes the object fields names by lower casing them. It also flattens the output of `files.ls`.

`files.ls` now returns an array of objects like:

```
{
	name: 'something',
    type: 0,
    size: 0,
    hash: 'something'
}
```

`files.stat` now returns an object like:

```
{
    type: 'file',
    size: 0,
    hash: 'something',
	blocks: 152,
	cumulativeSize: 0
}
```