### PR TITLE
feat: /api/v0/repo/version

### DIFF
--- a/src/repo/index.js
+++ b/src/repo/index.js
@@ -7,6 +7,7 @@ module.exports = (arg) => {
 
   return {
     gc: require('./gc')(send),
-    stat: require('./stat')(send)
+    stat: require('./stat')(send),
+    version: require('./version')(send)
   }
 }

--- a/src/repo/version.js
+++ b/src/repo/version.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const promisify = require('promisify-es6')
+
+module.exports = (send) => {
+  return promisify((opts, callback) => {
+    if (typeof (opts) === 'function') {
+      callback = opts
+      opts = {}
+    }
+    send({
+      path: 'repo/version',
+      qs: opts
+    }, callback)
+  })
+}

--- a/test/repo.spec.js
+++ b/test/repo.spec.js
@@ -44,6 +44,15 @@ describe('.repo', function () {
         done()
       })
     })
+
+    it('.repo.version', (done) => {
+      ipfs.repo.version((err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.exist()
+        expect(res).to.have.a.property('Version')        
+        done()
+      })
+    })
   })
 
   describe('Promise API', () => {
@@ -57,6 +66,14 @@ describe('.repo', function () {
           expect(res).to.exist()
           expect(res).to.have.a.property('NumObjects')
           expect(res).to.have.a.property('RepoSize')
+        })
+    })
+
+    it('.repo.version', () => {
+      return ipfs.repo.version()
+        .then(res => {
+          expect(res).to.exist()
+          expect(res).to.have.a.property('Version')
         })
     })
   })

--- a/test/repo.spec.js
+++ b/test/repo.spec.js
@@ -49,7 +49,7 @@ describe('.repo', function () {
       ipfs.repo.version((err, res) => {
         expect(err).to.not.exist()
         expect(res).to.exist()
-        expect(res).to.have.a.property('Version')        
+        expect(res).to.have.a.property('Version')
         done()
       })
     })


### PR DESCRIPTION
Add support for `api/v0/repo/version` calls.

related js-ipfs PR: [#1181](https://github.com/ipfs/js-ipfs/pull/1181)