### PR TITLE
Some fixes regarding the Stats API

### DIFF
--- a/src/bitswap/stat.js
+++ b/src/bitswap/stat.js
@@ -2,10 +2,24 @@
 
 const promisify = require('promisify-es6')
 
+const transform = function (res, callback) {
+  callback(null, {
+    provideBufLen: res.ProvideBufLen,
+    wantlist: res.Wantlist,
+    peers: res.Peers,
+    blocksReceived: res.BlocksReceived,
+    dataReceived: res.DataReceived,
+    blocksSent: res.BlocksSent,
+    dataSent: res.DataSent,
+    dupBlksReceived: res.DupBlksReceived,
+    dupDataReceived: res.DupDataReceived
+  })
+}
+
 module.exports = (send) => {
   return promisify((callback) => {
-    send({
+    send.andTransform({
       path: 'bitswap/stat'
-    }, callback)
+    }, transform, callback)
   })
 }

--- a/test/bitswap.spec.js
+++ b/test/bitswap.spec.js
@@ -41,12 +41,15 @@ describe('.bitswap', function () {
   it('.stat', (done) => {
     ipfs.bitswap.stat((err, res) => {
       expect(err).to.not.exist()
-      expect(res).to.have.property('BlocksReceived')
-      expect(res).to.have.property('DupBlksReceived')
-      expect(res).to.have.property('DupDataReceived')
-      expect(res).to.have.property('Peers')
-      expect(res).to.have.property('ProvideBufLen')
-      expect(res).to.have.property('Wantlist')
+      expect(res).to.have.a.property('provideBufLen')
+      expect(res).to.have.a.property('wantlist')
+      expect(res).to.have.a.property('peers')
+      expect(res).to.have.a.property('blocksReceived')
+      expect(res).to.have.a.property('dataReceived')
+      expect(res).to.have.a.property('blocksSent')
+      expect(res).to.have.a.property('dataSent')
+      expect(res).to.have.a.property('dupBlksReceived')
+      expect(res).to.have.a.property('dupDataReceived')
 
       done()
     })


### PR DESCRIPTION
- [x] Make `bitswap.stat` **equal to** `stats.bitswap`

This is also a breaking change.