### PR TITLE
feat(breaking change): use stream on stats.bw

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "go-ipfs-dep": "^0.4.13",
     "gulp": "^3.9.1",
     "hapi": "^16.6.2",
-    "interface-ipfs-core": "~0.43.0",
+    "interface-ipfs-core": "~0.47.0",
     "ipfsd-ctl": "~0.27.0",
     "pre-commit": "^1.2.2",
     "socket.io": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "async": "^2.6.0",
+    "big.js": "^5.0.3",
     "bs58": "^4.0.1",
     "cids": "~0.5.2",
     "concat-stream": "^1.6.0",
@@ -68,8 +69,8 @@
     "eslint-plugin-react": "^7.5.1",
     "go-ipfs-dep": "^0.4.13",
     "gulp": "^3.9.1",
-    "interface-ipfs-core": "~0.43.0",
     "hapi": "^16.6.2",
+    "interface-ipfs-core": "~0.43.0",
     "ipfsd-ctl": "~0.27.0",
     "pre-commit": "^1.2.2",
     "socket.io": "^2.0.4",

--- a/src/bitswap/stat.js
+++ b/src/bitswap/stat.js
@@ -5,8 +5,8 @@ const promisify = require('promisify-es6')
 const transform = function (res, callback) {
   callback(null, {
     provideBufLen: res.ProvideBufLen,
-    wantlist: res.Wantlist,
-    peers: res.Peers,
+    wantlist: res.Wantlist || [],
+    peers: res.Peers || [],
     blocksReceived: res.BlocksReceived,
     dataReceived: res.DataReceived,
     blocksSent: res.BlocksSent,

--- a/src/bitswap/stat.js
+++ b/src/bitswap/stat.js
@@ -1,18 +1,19 @@
 'use strict'
 
 const promisify = require('promisify-es6')
+const Big = require('big.js')
 
 const transform = function (res, callback) {
   callback(null, {
     provideBufLen: res.ProvideBufLen,
     wantlist: res.Wantlist || [],
     peers: res.Peers || [],
-    blocksReceived: res.BlocksReceived,
-    dataReceived: res.DataReceived,
-    blocksSent: res.BlocksSent,
-    dataSent: res.DataSent,
-    dupBlksReceived: res.DupBlksReceived,
-    dupDataReceived: res.DupDataReceived
+    blocksReceived: new Big(res.BlocksReceived),
+    dataReceived: new Big(res.DataReceived),
+    blocksSent: new Big(res.BlocksSent),
+    dataSent: new Big(res.DataSent),
+    dupBlksReceived: new Big(res.DupBlksReceived),
+    dupDataReceived: new Big(res.DupDataReceived)
   })
 }
 

--- a/src/repo/stat.js
+++ b/src/repo/stat.js
@@ -1,14 +1,15 @@
 'use strict'
 
 const promisify = require('promisify-es6')
+const Big = require('big.js')
 
 const transform = function (res, callback) {
   callback(null, {
-    numObjects: res.NumObjects,
-    repoSize: res.RepoSize,
+    numObjects: new Big(res.NumObjects),
+    repoSize: new Big(res.RepoSize),
     repoPath: res.RepoPath,
     version: res.Version,
-    storageMax: res.StorageMax
+    storageMax: new Big(res.StorageMax)
   })
 }
 

--- a/src/stats/bitswap.js
+++ b/src/stats/bitswap.js
@@ -5,8 +5,8 @@ const promisify = require('promisify-es6')
 const transform = function (res, callback) {
   callback(null, {
     provideBufLen: res.ProvideBufLen,
-    wantlist: res.Wantlist,
-    peers: res.Peers,
+    wantlist: res.Wantlist || [],
+    peers: res.Peers || [],
     blocksReceived: res.BlocksReceived,
     dataReceived: res.DataReceived,
     blocksSent: res.BlocksSent,

--- a/src/stats/bitswap.js
+++ b/src/stats/bitswap.js
@@ -1,18 +1,19 @@
 'use strict'
 
 const promisify = require('promisify-es6')
+const Big = require('big.js')
 
 const transform = function (res, callback) {
   callback(null, {
     provideBufLen: res.ProvideBufLen,
     wantlist: res.Wantlist || [],
     peers: res.Peers || [],
-    blocksReceived: res.BlocksReceived,
-    dataReceived: res.DataReceived,
-    blocksSent: res.BlocksSent,
-    dataSent: res.DataSent,
-    dupBlksReceived: res.DupBlksReceived,
-    dupDataReceived: res.DupDataReceived
+    blocksReceived: new Big(res.BlocksReceived),
+    dataReceived: new Big(res.DataReceived),
+    blocksSent: new Big(res.BlocksSent),
+    dataSent: new Big(res.DataSent),
+    dupBlksReceived: new Big(res.DupBlksReceived),
+    dupDataReceived: new Big(res.DupDataReceived)
   })
 }
 

--- a/src/stats/bw-pull-stream.js
+++ b/src/stats/bw-pull-stream.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const toPull = require('stream-to-pull-stream')
+const pull = require('pull-stream')
+const transformChunk = require('./bw-util')
+const deferred = require('pull-defer')
+
+const transform = () => (read) => (abort, cb) => {
+  read(abort, (err, data) => {
+    console.log(data)
+    if (err) return cb(err)
+    cb(null, transformChunk(data))
+  })
+}
+
+module.exports = (send) => {
+  return (hash, opts) => {
+    opts = opts || {}
+
+    const p = deferred.through()
+
+    send({
+      path: 'stats/bw',
+      qs: opts
+    }, (err, stream) => {
+      if (err) {
+        return p.end(err)
+      }
+
+      pull(toPull(stream), p)
+      p.resolve(transform)
+    })
+
+    return p
+  }
+}

--- a/src/stats/bw-readable-stream.js
+++ b/src/stats/bw-readable-stream.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const Stream = require('readable-stream')
+const pump = require('pump')
+const transformChunk = require('./bw-util')
+
+module.exports = (send) => {
+  return (hash, opts) => {
+    opts = opts || {}
+
+    const pt = new Stream.Transform({
+      objectMode: true,
+      transform (chunk, encoding, cb) {
+        cb(null, transformChunk(chunk))
+      }
+    })
+
+    send({
+      path: 'stats/bw',
+      qs: opts
+    }, (err, stream) => {
+      if (err) {
+        return pt.destroy(err)
+      }
+
+      pump(stream, pt)
+    })
+
+    return pt
+  }
+}

--- a/src/stats/bw-util.js
+++ b/src/stats/bw-util.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const Big = require('big.js')
+
+module.exports = (chunk) => {
+  return {
+    totalIn: new Big(chunk.TotalIn),
+    totalOut: new Big(chunk.TotalOut),
+    rateIn: new Big(chunk.RateIn),
+    rateOut: new Big(chunk.RateOut)
+  }
+}

--- a/src/stats/bw.js
+++ b/src/stats/bw.js
@@ -2,20 +2,15 @@
 
 const promisify = require('promisify-es6')
 const streamToValue = require('../utils/stream-to-value')
+const { Transform } = require('readable-stream')
 
-const transform = function (res, callback) {
-  streamToValue(res, (err, data) => {
-    if (err) {
-      return callback(err)
-    }
-
-    callback(null, {
-      totalIn: data[0].TotalIn,
-      totalOut: data[0].TotalOut,
-      rateIn: data[0].RateIn,
-      rateOut: data[0].RateOut
-    })
-  })
+const transformChunk = (chunk) => {
+  return {
+    totalIn: chunk.TotalIn,
+    totalOut: chunk.TotalOut,
+    rateIn: chunk.RateIn,
+    rateOut: chunk.RateOut
+  }
 }
 
 module.exports = (send) => {
@@ -28,6 +23,28 @@ module.exports = (send) => {
     send.andTransform({
       path: 'stats/bw',
       qs: opts
-    }, transform, callback)
+    }, (res, callback) => {
+      if (!opts.poll) {
+        // If not polling, just send the result.
+        return streamToValue(res, (err, data) => {
+          if (err) {
+            return callback(err)
+          }
+
+          callback(null, transformChunk(data[0]))
+        })
+      }
+
+      // If polling, return a readable stream.
+      const output = new Transform({
+        objectMode: true,
+        transform (chunk, encoding, cb) {
+          cb(null, transformChunk(chunk))
+        }
+      })
+
+      res.pipe(output)
+      callback(null, output)
+    }, callback)
   })
 }

--- a/src/stats/bw.js
+++ b/src/stats/bw.js
@@ -2,15 +2,16 @@
 
 const promisify = require('promisify-es6')
 const streamToValue = require('../utils/stream-to-value')
-const { Transform } = require('readable-stream')
+const transformChunk = require('./bw-util')
 
-const transformChunk = (chunk) => {
-  return {
-    totalIn: chunk.TotalIn,
-    totalOut: chunk.TotalOut,
-    rateIn: chunk.RateIn,
-    rateOut: chunk.RateOut
-  }
+const transform = (res, callback) => {
+  return streamToValue(res, (err, data) => {
+    if (err) {
+      return callback(err)
+    }
+
+    callback(null, transformChunk(data[0]))
+  })
 }
 
 module.exports = (send) => {
@@ -23,28 +24,6 @@ module.exports = (send) => {
     send.andTransform({
       path: 'stats/bw',
       qs: opts
-    }, (res, callback) => {
-      if (!opts.poll) {
-        // If not polling, just send the result.
-        return streamToValue(res, (err, data) => {
-          if (err) {
-            return callback(err)
-          }
-
-          callback(null, transformChunk(data[0]))
-        })
-      }
-
-      // If polling, return a readable stream.
-      const output = new Transform({
-        objectMode: true,
-        transform (chunk, encoding, cb) {
-          cb(null, transformChunk(chunk))
-        }
-      })
-
-      res.pipe(output)
-      callback(null, output)
-    }, callback)
+    }, transform, callback)
   })
 }

--- a/src/stats/index.js
+++ b/src/stats/index.js
@@ -8,6 +8,8 @@ module.exports = (arg) => {
   return {
     bitswap: require('./bitswap')(send),
     bw: require('./bw')(send),
+    bwReadableStream: require('./bw-readable-stream')(send),
+    bwPullStream: require('./bw-pull-stream')(send),
     repo: require('./repo')(send)
   }
 }

--- a/src/stats/repo.js
+++ b/src/stats/repo.js
@@ -1,14 +1,15 @@
 'use strict'
 
 const promisify = require('promisify-es6')
+const Big = require('big.js')
 
 const transform = function (res, callback) {
   callback(null, {
-    numObjects: res.NumObjects,
-    repoSize: res.RepoSize,
+    numObjects: new Big(res.NumObjects),
+    repoSize: new Big(res.RepoSize),
     repoPath: res.RepoPath,
     version: res.Version,
-    storageMax: res.StorageMax
+    storageMax: new Big(res.StorageMax)
   })
 }
 


### PR DESCRIPTION
`stats.bw` has an option called `poll` which allows the user to "tell" IPFS to send bandwidth stats each interval of time. We were collecting the response before calling the callback so that option would be useless. 

This way it sends a stream to the callback so the user can listen to `data` event which contains the Object.

Interface IPFS core update: https://github.com/ipfs/interface-ipfs-core/pull/211