### PR TITLE
Make `ls` links' depth dynamic.

### DIFF
--- a/src/ls.js
+++ b/src/ls.js
@@ -41,7 +41,7 @@ module.exports = (arg) => {
         size: link.Size,
         hash: link.Hash,
         type: typeOf(link),
-        depth: link.Depth
+        depth: link.Depth || 1
       }))
 
       callback(null, result)

--- a/src/ls.js
+++ b/src/ls.js
@@ -36,12 +36,12 @@ module.exports = (arg) => {
       }
 
       result = result.map((link) => ({
-        depth: 1,
         name: link.Name,
         path: args + '/' + link.Name,
         size: link.Size,
         hash: link.Hash,
-        type: typeOf(link)
+        type: typeOf(link),
+        depth: link.Depth
       }))
 
       callback(null, result)


### PR DESCRIPTION
To be able to prettily print `ipfs ls -r`, we need to know the depth of each file from the `ls` command.

It was previously hardcoded a 1, though I don't know why. I'm passing the depth along from a change I made in js-ipfs [here](https://github.com/ipfs/js-ipfs/pull/1222/files#diff-dcaf16a1df33e0e8f40195e527b9294dR293).

The b58 hash test for `ls` should fail in CI because the above change to js-ipfs is required to receive the links' depth. Unfortunately this is a cyclical dependency. I can fix it by breaking out the change to js-ipfs or we can merge and fix if something comes up. lemme know

ref: https://github.com/ipfs/js-ipfs/pull/1222
