### PR TITLE
add support for ipfs files stat --with-local

### DIFF
--- a/src/files/stat.js
+++ b/src/files/stat.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const promisify = require('promisify-es6')
+const _ = require('lodash')
 
 const transform = function (res, callback) {
   callback(null, {
@@ -8,7 +9,10 @@ const transform = function (res, callback) {
     blocks: res.Blocks,
     size: res.Size,
     hash: res.Hash,
-    cumulativeSize: res.CumulativeSize
+    cumulativeSize: res.CumulativeSize,
+    withLocality: res.WithLocality || false,
+    local: res.Local || undefined,
+    sizeLocal: res.SizeLocal || undefined
   })
 }
 
@@ -18,6 +22,9 @@ module.exports = (send) => {
       callback = opts
       opts = {}
     }
+
+    opts = _.mapKeys(opts, (v, k) => _.kebabCase(k))
+
     send.andTransform({
       path: 'files/stat',
       args: args,

--- a/src/files/stat.js
+++ b/src/files/stat.js
@@ -2,17 +2,24 @@
 
 const promisify = require('promisify-es6')
 const _ = require('lodash')
+const streamToValue = require('../utils/stream-to-value')
 
 const transform = function (res, callback) {
-  callback(null, {
-    type: res.Type,
-    blocks: res.Blocks,
-    size: res.Size,
-    hash: res.Hash,
-    cumulativeSize: res.CumulativeSize,
-    withLocality: res.WithLocality || false,
-    local: res.Local || undefined,
-    sizeLocal: res.SizeLocal || undefined
+  return streamToValue(res, (err, data) => {
+    if (err) {
+      return callback(err)
+    }
+
+    callback(null, {
+      type: data[0].Type,
+      blocks: data[0].Blocks,
+      size: data[0].Size,
+      hash: data[0].Hash,
+      cumulativeSize: data[0].CumulativeSize,
+      withLocality: data[0].WithLocality || false,
+      local: data[0].Local || null,
+      sizeLocal: data[0].SizeLocal || null
+    })
   })
 }
 

--- a/test/files.spec.js
+++ b/test/files.spec.js
@@ -282,7 +282,10 @@ describe('.files (the MFS API part)', function () {
         size: 12,
         cumulativeSize: 20,
         blocks: 0,
-        type: 'file'
+        type: 'file',
+        withLocality: false,
+        local: undefined,
+        sizeLocal: undefined
       })
 
       done()


### PR DESCRIPTION
So, I upgraded my js-ipfs-api and found out that the support for `ipfs files stat --with-local` was broken after 98000af3fe9c15aa7f6a594f760bff2f3d373095 (the response object is not relayed entirely anymore, so the new values get dropped).

Another problem I had and that is not solved yet by this PR is that due to the migration in go-ipfs to the new `go-ipfs-cmds` framework (https://github.com/ipfs/go-ipfs/pull/4638), the command `ipfs files stat` now reply with a stream which is not converted properly in values by js-ipfs-api. There is two way to solve that problem:
- convert the stream in a single value in js-ipfs-api
- use `cmds.EmitOnce` in go-ipfs to hint the ReponseEmitter and reply without streaming

Do you have a preference ?

CC @whyrusleeping, @Stebalien 