### PR TITLE
Chore: set package.json's main to dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ipfs-api",
   "version": "18.1.1",
   "description": "A client library for the IPFS HTTP API",
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "browser": {
     "glob": false,
     "fs": false,


### PR DESCRIPTION
The `main` field should probably be pointing to the built version, rather than the original src. Without this, some module bundlers (and uglify) will choke.