### PR TITLE
Set the FileStreamConverter explicitly 

### DIFF
--- a/src/files/add-pull-stream.js
+++ b/src/files/add-pull-stream.js
@@ -1,6 +1,13 @@
 'use strict'
 
 const SendFilesStream = require('../utils/send-files-stream')
+const FileResultStreamConverter = require('../utils/file-result-stream-converter')
 const toPull = require('stream-to-pull-stream')
 
-module.exports = (send) => (options) => toPull(SendFilesStream(send, 'add')(options))
+module.exports = (send) => {
+  return (options) => {
+    options = options || {}
+    options.converter = FileResultStreamConverter
+    return toPull(SendFilesStream(send, 'add')(options))
+  }
+}

--- a/src/files/add-readable-stream.js
+++ b/src/files/add-readable-stream.js
@@ -1,5 +1,12 @@
 'use strict'
 
 const SendFilesStream = require('../utils/send-files-stream')
+const FileResultStreamConverter = require('../utils/file-result-stream-converter')
 
-module.exports = (send) => SendFilesStream(send, 'add')
+module.exports = (send) => {
+  return (options) => {
+    options = options || {}
+    options.converter = FileResultStreamConverter
+    return SendFilesStream(send, 'add')(options)
+  }
+}

--- a/src/files/add.js
+++ b/src/files/add.js
@@ -5,6 +5,7 @@ const ConcatStream = require('concat-stream')
 const once = require('once')
 const isStream = require('is-stream')
 const OtherBuffer = require('buffer').Buffer
+const FileResultStreamConverter = require('../utils/file-result-stream-converter')
 const SendFilesStream = require('../utils/send-files-stream')
 
 module.exports = (send) => {
@@ -21,6 +22,7 @@ module.exports = (send) => {
     if (!options) {
       options = {}
     }
+    options.converter = FileResultStreamConverter
 
     const ok = Buffer.isBuffer(_files) ||
                isStream.readable(_files) ||

--- a/src/files/write.js
+++ b/src/files/write.js
@@ -3,6 +3,7 @@
 const promisify = require('promisify-es6')
 const concatStream = require('concat-stream')
 const once = require('once')
+const FileResultStreamConverter = require('../utils/file-result-stream-converter')
 const SendFilesStream = require('../utils/send-files-stream')
 
 module.exports = (send) => {
@@ -28,7 +29,8 @@ module.exports = (send) => {
 
     const options = {
       args: pathDst,
-      qs: opts
+      qs: opts,
+      converter: FileResultStreamConverter
     }
 
     const stream = sendFilesStream(options)

--- a/src/util/fs-add.js
+++ b/src/util/fs-add.js
@@ -4,6 +4,7 @@ const isNode = require('detect-node')
 const promisify = require('promisify-es6')
 const moduleConfig = require('../utils/module-config')
 const SendOneFile = require('../utils/send-one-file-multiple-results')
+const FileResultStreamConverter = require('../utils/file-result-stream-converter')
 
 module.exports = (arg) => {
   const sendOneFile = SendOneFile(moduleConfig(arg), 'add')
@@ -31,6 +32,10 @@ module.exports = (arg) => {
       return callback(new Error('"path" must be a string'))
     }
 
-    sendOneFile(path, { qs: opts }, callback)
+    const requestOpts = {
+      qs: opts,
+      converter: FileResultStreamConverter
+    }
+    sendOneFile(path, requestOpts, callback)
   })
 }

--- a/src/util/url-add.js
+++ b/src/util/url-add.js
@@ -5,6 +5,7 @@ const parseUrl = require('url').parse
 const request = require('../utils/request')
 const moduleConfig = require('../utils/module-config')
 const SendOneFile = require('../utils/send-one-file-multiple-results')
+const FileResultStreamConverter = require('../utils/file-result-stream-converter')
 
 module.exports = (arg) => {
   const sendOneFile = SendOneFile(moduleConfig(arg), 'add')
@@ -49,7 +50,11 @@ const requestWithRedirect = (url, opts, sendOneFile, callback) => {
       }
       requestWithRedirect(redirection, opts, sendOneFile, callback)
     } else {
-      sendOneFile(res, { qs: opts }, callback)
+      const requestOpts = {
+        qs: opts,
+        converter: FileResultStreamConverter
+      }
+      sendOneFile(res, requestOpts, callback)
     }
   }).end()
 }

--- a/src/utils/converter.js
+++ b/src/utils/converter.js
@@ -1,8 +1,6 @@
 'use strict'
 
-const pump = require('pump')
 const TransformStream = require('readable-stream').Transform
-const streamToValue = require('./stream-to-value')
 
 /*
   Transforms a stream of {Name, Hash} objects to include size
@@ -43,19 +41,4 @@ class ConverterStream extends TransformStream {
   }
 }
 
-function converter (inputStream, callback) {
-  const outputStream = new ConverterStream()
-  pump(
-    inputStream,
-    outputStream,
-    (err) => {
-      if (err) {
-        callback(err)
-      }
-    })
-
-  streamToValue(outputStream, callback)
-}
-
-exports = module.exports = converter
-exports.ConverterStream = ConverterStream
+module.exports = ConverterStream

--- a/src/utils/file-result-stream-converter.js
+++ b/src/utils/file-result-stream-converter.js
@@ -6,7 +6,7 @@ const TransformStream = require('readable-stream').Transform
   Transforms a stream of {Name, Hash} objects to include size
   of the DAG object.
 
-  Usage: inputStream.pipe(new Converter())
+  Usage: inputStream.pipe(new FileResultStreamConverter())
 
   Input object format:
   {
@@ -22,7 +22,7 @@ const TransformStream = require('readable-stream').Transform
     size: 20
   }
 */
-class ConverterStream extends TransformStream {
+class FileResultStreamConverter extends TransformStream {
   constructor (options) {
     const opts = Object.assign({}, options || {}, { objectMode: true })
     super(opts)
@@ -41,4 +41,4 @@ class ConverterStream extends TransformStream {
   }
 }
 
-module.exports = ConverterStream
+module.exports = FileResultStreamConverter

--- a/src/utils/send-files-stream.js
+++ b/src/utils/send-files-stream.js
@@ -6,7 +6,7 @@ const isStream = require('is-stream')
 const once = require('once')
 const prepareFile = require('./prepare-file')
 const Multipart = require('./multipart')
-const Converter = require('./converter').ConverterStream
+const Converter = require('./converter')
 
 function headers (file) {
   const name = file.path


### PR DESCRIPTION
The `SendFilesStream` used to run the `FileStreamConverter` automatically.
With making it an option to use a converter, `SendFilesStream` can be
used outside of the Files API, e.g. for the DAG API.