### PR TITLE
chore: disable Browser tests on CI for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
 
 script:
   - npm run lint
-  - npm run test
+  - npm run test:node
   - npm run coverage
 
 before_script:

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,8 @@ machine:
     version: stable
 
 test:
+  override:
+    - npm run test:node
   post:
     - npm run coverage -- --upload --providers coveralls
 


### PR DESCRIPTION
Currently the Browser tests fail to a known issue. Therefore disable
them for now and run the tests only on node. Some CI is better
than none CI.