### PR TITLE
fix: webpack bundle tests only once

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "url": "https://github.com/ipfs/js-ipfs-api"
   },
   "devDependencies": {
-    "aegir": "^13.0.0",
+    "aegir": "^14.0.0",
     "chai": "^4.1.2",
     "dirty-chai": "^2.0.1",
     "eslint-plugin-react": "^7.6.1",

--- a/test/browser.js
+++ b/test/browser.js
@@ -1,0 +1,6 @@
+// This is webpack specific. It will create a single bundle
+// out of all files ending in ".spec.js" within the "test"
+// directory and all its subdirectories.
+'use strict'
+const testsContext = require.context('.', true, /\.spec\.js/)
+testsContext.keys().forEach(testsContext)


### PR DESCRIPTION
Prior to this change there was a webpack bundle for every test file
which lead to very high memory usage. Now the tests are webpacked
only once into a single big file.

Closes #683.

This change depends on https://github.com/ipfs/aegir/pull/202.