### PR TITLE
fix: validates and serializes cid argument to dht.provide

### DIFF
--- a/src/dht/provide.js
+++ b/src/dht/provide.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const promisify = require('promisify-es6')
+const CID = require('cids')
 
 module.exports = (send) => {
   return promisify((cids, opts, callback) => {
@@ -18,6 +19,13 @@ module.exports = (send) => {
 
     if (!Array.isArray(cids)) {
       cids = [cids]
+    }
+
+    // Validate CID(s) and serialize
+    try {
+      cids = cids.map(cid => new CID(cid).toBaseEncodedString('base58btc'))
+    } catch (err) {
+      return callback(err)
     }
 
     send({


### PR DESCRIPTION
This PR validates that the `cid` argument passed to provide is a CID and also serializes it to a base58 encoded string as the serialization job done by `qs` appears to be ignored by go-ipfs.

Please see [this discussion](https://github.com/ipfs/interface-ipfs-core/pull/221#issuecomment-370938018) for the context.