### PR TITLE
fix: disable Browser test on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "devDependencies": {
     "aegir": "^13.0.6",
+    "browser-process-platform": "^0.1.1",
     "chai": "^4.1.2",
     "cross-env": "^5.1.3",
     "dirty-chai": "^2.0.1",

--- a/test/diag.spec.js
+++ b/test/diag.spec.js
@@ -5,7 +5,7 @@ const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
-const os = require('os')
+const platform = require('browser-process-platform')
 
 const IPFSApi = require('../src')
 const f = require('./utils/factory')
@@ -14,7 +14,7 @@ describe('.diag', function () {
   this.timeout(50 * 1000)
 
   // go-ipfs does not support these on Windows
-  if (os.platform() === 'win32') { return }
+  if (platform === 'win32') { return }
 
   let ipfsd
   let ipfs


### PR DESCRIPTION
`process.platform` is only available in Node.js and not in the Browsers.
Hence the `diag.spec.js` tests weren't correctly skipped on Windows.