### PR TITLE
Use a different remote server for test

### DIFF
--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -113,9 +113,9 @@ describe('.util', () => {
   })
 
   it('.urlAdd http with redirection', (done) => {
-    ipfs.util.addFromURL('http://covers.openlibrary.org/book/id/969165.jpg', (err, result) => {
+    ipfs.util.addFromURL('https://coverartarchive.org/release/6e2a1694-d8b9-466a-aa33-b1077b2333c1', (err, result) => {
       expect(err).to.not.exist()
-      expect(result[0].hash).to.equal('QmaL9zy7YUfvWmtD5ZXp42buP7P4xmZJWFkm78p8FJqgjg')
+      expect(result[0].hash).to.equal('QmSUdDvmXuq5YGrL4M3SEz7UZh5eT9WMuAsd9K34sambSj')
       done()
     })
   })


### PR DESCRIPTION
The previous server had issues, so the test timed out. Hopefully
this on is more stable.