### PR TITLE
Cleanup upload-via-browser example

### DIFF
--- a/examples/upload-file-via-browser/src/App.js
+++ b/examples/upload-file-via-browser/src/App.js
@@ -13,7 +13,6 @@ class App extends React.Component {
     // bind methods
     this.captureFile = this.captureFile.bind(this)
     this.saveToIpfs = this.saveToIpfs.bind(this)
-    this.arrayBufferToString = this.arrayBufferToString.bind(this)
     this.handleSubmit = this.handleSubmit.bind(this)
   }
 
@@ -38,10 +37,6 @@ class App extends React.Component {
       }).catch((err) => {
         console.error(err)
       })
-  }
-
-  arrayBufferToString (arrayBuffer) {
-    return String.fromCharCode.apply(null, new Uint16Array(arrayBuffer))
   }
 
   handleSubmit (event) {


### PR DESCRIPTION
While trying to look at the upload-via-browser example, I spent some time trying to figure out what arrayBufferToString was supposed to do and it looks like it's some leftover from a previous version of the example and it's currently not being used.

 It would be great to have this removed in order to avoid confusion.