### PR TITLE
Allow files.cat to accept a cid instance

### DIFF
--- a/src/utils/clean-cid.js
+++ b/src/utils/clean-cid.js
@@ -7,6 +7,9 @@ module.exports = function (cid) {
   if (Buffer.isBuffer(cid)) {
     cid = bs58.encode(cid)
   }
+  if (CID.isCID(cid)) {
+    cid = cid.toBaseEncodedString()
+  }
   if (typeof cid !== 'string') {
     throw new Error('unexpected cid type: ' + typeof cid)
   }


### PR DESCRIPTION
Implements the spec addition at ipfs/interface-ipfs-core#243, allowing users to use the cid instance itself to cat files.

This has been tested against the added tests from ipfs/interface-ipfs-core#243 via `npm link`

connects ipfs/js-ipfs#1229