### PR TITLE
feat: streamable ping and optional packet number

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,9 @@ $ ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods "[\"PUT\", \"P
 - [miscellaneous operations](https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/MISCELLANEOUS.md)
   - [`ipfs.id([callback])`](https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/MISCELLANEOUS.md#id)
   - [`ipfs.version([callback])`](https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/MISCELLANEOUS.md#version)
-  - [`ipfs.ping()`](https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/MISCELLANEOUS.md#ping)
+  - [`ipfs.ping(id, [options, callback])`](https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/MISCELLANEOUS.md#ping)
+  - `ipfs.pingPullStream(id, [options])`
+  - `ipfs.pingReadableStream(id, [options])`
   - [`ipfs.dns(domain, [callback])`](https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/MISCELLANEOUS.md#dns)
   - [`ipfs.stop([callback])`](https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/MISCELLANEOUS.md#stop). Alias to `ipfs.shutdown`.
   

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "ipfs": "~0.28.2",
     "ipfsd-ctl": "~0.30.1",
     "pre-commit": "^1.2.2",
+    "pull-catch": "^1.0.0",
     "socket.io": "^2.0.4",
     "socket.io-client": "^2.0.4",
     "stream-equal": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "ipfs": "~0.28.2",
     "ipfsd-ctl": "~0.30.1",
     "pre-commit": "^1.2.2",
+    "pull-stream": "^3.6.2",
     "socket.io": "^2.0.4",
     "socket.io-client": "^2.0.4",
     "stream-equal": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "ipfs": "~0.28.2",
     "ipfsd-ctl": "~0.30.1",
     "pre-commit": "^1.2.2",
-    "pull-catch": "^1.0.0",
     "socket.io": "^2.0.4",
     "socket.io-client": "^2.0.4",
     "stream-equal": "^1.1.1"

--- a/src/ping-pull-stream.js
+++ b/src/ping-pull-stream.js
@@ -20,7 +20,7 @@ module.exports = (arg) => {
     const p = deferred.source()
 
     send(request, (err, stream) => {
-      if (err) { return p.abort(err)  }
+      if (err) { return p.abort(err) }
       p.resolve(toPull.source(stream))
     })
 

--- a/src/ping-pull-stream.js
+++ b/src/ping-pull-stream.js
@@ -2,8 +2,6 @@
 
 const toPull = require('stream-to-pull-stream')
 const deferred = require('pull-defer')
-const pull = require('pull-stream')
-const log = require('pull-stream/sinks/log')
 const moduleConfig = require('./utils/module-config')
 
 module.exports = (arg) => {
@@ -22,7 +20,7 @@ module.exports = (arg) => {
 		const p = deferred.source()
 
 		send(request, (err, stream) => {
-			if (err) { return p.end(err)  }
+			if (err) { return p.abort(err)  }
       p.resolve(toPull.source(stream))
 		})
 

--- a/src/ping-pull-stream.js
+++ b/src/ping-pull-stream.js
@@ -16,14 +16,14 @@ module.exports = (arg) => {
       path: 'ping',
       args: id,
       qs: opts
-		}
-		const p = deferred.source()
+    }
+    const p = deferred.source()
 
-		send(request, (err, stream) => {
-			if (err) { return p.abort(err)  }
+    send(request, (err, stream) => {
+      if (err) { return p.abort(err)  }
       p.resolve(toPull.source(stream))
-		})
+    })
 
-		return p
-	}
+    return p
+  }
 }

--- a/src/ping-pull-stream.js
+++ b/src/ping-pull-stream.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const toPull = require('stream-to-pull-stream')
+const deferred = require('pull-defer')
+const pull = require('pull-stream')
+const log = require('pull-stream/sinks/log')
+const moduleConfig = require('./utils/module-config')
+
+module.exports = (arg) => {
+  const send = moduleConfig(arg)
+
+  return (id, opts = {}) => {
+    // Default number of packtes to 1
+    if (!opts.n && !opts.count) {
+      opts.n = 1
+    }
+    const request = {
+      path: 'ping',
+      args: id,
+      qs: opts
+		}
+		const p = deferred.source()
+
+		send(request, (err, stream) => {
+			if (err) { return p.end(err)  }
+      p.resolve(toPull.source(stream))
+		})
+
+		return p
+	}
+}

--- a/src/ping-readable-stream.js
+++ b/src/ping-readable-stream.js
@@ -24,7 +24,7 @@ module.exports = (arg) => {
 
     send(request, (err, stream) => {
       if (err) { return pt.destroy(err) }
-      
+
       pump(stream, pt)
     })
 

--- a/src/ping-readable-stream.js
+++ b/src/ping-readable-stream.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const Stream = require('readable-stream')
+const pump = require('pump')
+const moduleConfig = require('./utils/module-config')
+
+module.exports = (arg) => {
+  const send = moduleConfig(arg)
+
+  return (id, opts = {}) => {
+    // Default number of packtes to 1
+    if (!opts.n && !opts.count) {
+      opts.n = 1
+    }
+    const request = {
+      path: 'ping',
+      args: id,
+      qs: opts
+    }
+		// ndjson streams objects
+    const pt = new Stream.PassThrough({
+			objectMode: true
+		})
+
+    send(request, (err, stream) => {
+      if (err) { return pt.destroy(err) }
+      
+      pump(stream, pt)
+    })
+
+    return pt
+  }
+}

--- a/src/ping-readable-stream.js
+++ b/src/ping-readable-stream.js
@@ -17,10 +17,10 @@ module.exports = (arg) => {
       args: id,
       qs: opts
     }
-		// ndjson streams objects
+    // ndjson streams objects
     const pt = new Stream.PassThrough({
-			objectMode: true
-		})
+      objectMode: true
+    })
 
     send(request, (err, stream) => {
       if (err) { return pt.destroy(err) }

--- a/src/ping.js
+++ b/src/ping.js
@@ -7,30 +7,30 @@ const streamToValue = require('./utils/stream-to-value')
 module.exports = (arg) => {
   const send = moduleConfig(arg)
 
-  return promisify((id, callback) => {
+  return promisify((id, opts, callback) => {
+    if (typeof opts === 'function') {
+      callback = opts
+      opts = {}
+    }
+    // Default number of packtes to 1
+    if (!opts.n && !opts.count) {
+      opts.n = 1
+    }
     const request = {
       path: 'ping',
       args: id,
-      qs: { n: 1 }
+      qs: opts
     }
 
     // Transform the response stream to a value:
-    // { Success: <boolean>, Time: <number>, Text: <string> }
+    // [{ Success: <boolean>, Time: <number>, Text: <string> }]
     const transform = (res, callback) => {
       streamToValue(res, (err, res) => {
         if (err) {
           return callback(err)
         }
 
-        // go-ipfs http api currently returns 3 lines for a ping.
-        // they're a little messed, so take the correct values from each lines.
-        const pingResult = {
-          Success: res[1].Success,
-          Time: res[1].Time,
-          Text: res[2].Text
-        }
-
-        callback(null, pingResult)
+        callback(null, res)
       })
     }
 

--- a/src/utils/load-commands.js
+++ b/src/utils/load-commands.js
@@ -31,6 +31,8 @@ function requireCommands () {
     object: require('../object'),
     pin: require('../pin'),
     ping: require('../ping'),
+    pingReadableStream: require('../ping-readable-stream'),
+    pingPullStream: require('../ping-pull-stream'),
     refs: require('../refs'),
     repo: require('../repo'),
     stop: require('../stop'),

--- a/src/utils/send-request.js
+++ b/src/utils/send-request.js
@@ -34,9 +34,11 @@ function onRes (buffer, cb) {
     const chunkedObjects = Boolean(res.headers['x-chunked-output'])
     const isJson = res.headers['content-type'] &&
                    res.headers['content-type'].indexOf('application/json') === 0
+
     if (res.statusCode >= 400 || !res.statusCode) {
       return parseError(res, cb)
     }
+
     // Return the response stream directly
     if (stream && !buffer) {
       return cb(null, res)

--- a/src/utils/send-request.js
+++ b/src/utils/send-request.js
@@ -34,11 +34,9 @@ function onRes (buffer, cb) {
     const chunkedObjects = Boolean(res.headers['x-chunked-output'])
     const isJson = res.headers['content-type'] &&
                    res.headers['content-type'].indexOf('application/json') === 0
-
     if (res.statusCode >= 400 || !res.statusCode) {
       return parseError(res, cb)
     }
-
     // Return the response stream directly
     if (stream && !buffer) {
       return cb(null, res)

--- a/test/ping.spec.js
+++ b/test/ping.spec.js
@@ -139,7 +139,7 @@ describe('.ping', function () {
       return ipfs.ping(otherId, {count: 3})
         .then((res) => {
           expect(res).to.be.an('array')
-          expect(res).to.have.lengthOf(3)
+          expect(res).to.have.lengthOf(5)
           res.forEach(packet => {
             expect(packet).to.have.keys('Success', 'Time', 'Text')
             expect(packet.Time).to.be.a('number')

--- a/test/ping.spec.js
+++ b/test/ping.spec.js
@@ -14,7 +14,7 @@ const series = require('async/series')
 const IPFSApi = require('../src')
 const f = require('./utils/factory')
 
-describe('.ping',function () {
+describe('.ping', function () {
   let ipfs
   let ipfsd
   let other
@@ -164,7 +164,7 @@ describe('.ping',function () {
     })
 
     it('sending both n and count should fail', (done) => {
-      ipfs.ping(otherId, {n: 3, count:3})
+      ipfs.ping(otherId, {n: 3, count: 3})
         .catch(err => {
           expect(err).to.exist()
           done()
@@ -208,7 +208,6 @@ describe('.ping',function () {
         })
       )
     })
-
 
     it('ping another peer with a specifc packet count through parameter n', (done) => {
       pull(
@@ -292,7 +291,7 @@ describe('.ping',function () {
     })
 
     it('sending both n and count should fail', (done) => {
-      ipfs.pingReadableStream(otherId, {n: 3, count:3})
+      ipfs.pingReadableStream(otherId, {n: 3, count: 3})
         .on('error', err => {
           expect(err).to.exist()
           done()

--- a/test/ping.spec.js
+++ b/test/ping.spec.js
@@ -19,7 +19,7 @@ describe('.ping',function () {
   let ipfsd
   let other
   let otherd
-	let otherId
+  let otherId
 
   before(function (done) {
     this.timeout(20 * 1000) // slow CI
@@ -53,7 +53,7 @@ describe('.ping',function () {
         other.id((err, id) => {
           expect(err).to.not.exist()
           otherId = id.id
-					cb()
+          cb()
         })
       }
     ], done)
@@ -68,56 +68,56 @@ describe('.ping',function () {
 
   describe('callback API', () => {
     it('ping another peer with default packet count', (done) => {
-			ipfs.ping(otherId, (err, res) => {
-				expect(err).to.not.exist()
-				expect(res).to.be.an('array')
-				expect(res).to.have.lengthOf(3)
-				res.forEach(packet => {
-					expect(packet).to.have.keys('Success', 'Time', 'Text')
-					expect(packet.Time).to.be.a('number')
-				})
-				const resultMsg = res.find(packet => packet.Text.includes('Average latency'))
-				expect(resultMsg).to.exist()
-				done()
-			})
+      ipfs.ping(otherId, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.be.an('array')
+        expect(res).to.have.lengthOf(3)
+        res.forEach(packet => {
+          expect(packet).to.have.keys('Success', 'Time', 'Text')
+          expect(packet.Time).to.be.a('number')
+        })
+        const resultMsg = res.find(packet => packet.Text.includes('Average latency'))
+        expect(resultMsg).to.exist()
+        done()
+      })
     })
 
-		it('ping another peer with a specifc packet count through parameter count', (done) => {
-			ipfs.ping(otherId, {count: 3}, (err, res) => {
-				expect(err).to.not.exist()
-				expect(res).to.be.an('array')
-				expect(res).to.have.lengthOf(5)
-				res.forEach(packet => {
-					expect(packet).to.have.keys('Success', 'Time', 'Text')
-					expect(packet.Time).to.be.a('number')
-				})
-				const resultMsg = res.find(packet => packet.Text.includes('Average latency'))
-				expect(resultMsg).to.exist()
-				done()
-			})
-		})
+    it('ping another peer with a specifc packet count through parameter count', (done) => {
+      ipfs.ping(otherId, {count: 3}, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.be.an('array')
+        expect(res).to.have.lengthOf(5)
+        res.forEach(packet => {
+          expect(packet).to.have.keys('Success', 'Time', 'Text')
+          expect(packet.Time).to.be.a('number')
+        })
+        const resultMsg = res.find(packet => packet.Text.includes('Average latency'))
+        expect(resultMsg).to.exist()
+        done()
+      })
+    })
 
-		it('ping another peer with a specifc packet count through parameter n', (done) => {
-			ipfs.ping(otherId, {n: 3}, (err, res) => {
-				expect(err).to.not.exist()
-				expect(res).to.be.an('array')
-				expect(res).to.have.lengthOf(5)
-				res.forEach(packet => {
-					expect(packet).to.have.keys('Success', 'Time', 'Text')
-					expect(packet.Time).to.be.a('number')
-				})
-				const resultMsg = res.find(packet => packet.Text.includes('Average latency'))
-				expect(resultMsg).to.exist()
-				done()
-			})
-		})
+    it('ping another peer with a specifc packet count through parameter n', (done) => {
+      ipfs.ping(otherId, {n: 3}, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.be.an('array')
+        expect(res).to.have.lengthOf(5)
+        res.forEach(packet => {
+          expect(packet).to.have.keys('Success', 'Time', 'Text')
+          expect(packet.Time).to.be.a('number')
+        })
+        const resultMsg = res.find(packet => packet.Text.includes('Average latency'))
+        expect(resultMsg).to.exist()
+        done()
+      })
+    })
 
-		it('sending both n and count should fail', (done) => {
-			ipfs.ping(otherId, {count: 10, n: 10}, (err, res) => {
-				expect(err).to.exist()
-				done()
-			})
-		})
+    it('sending both n and count should fail', (done) => {
+      ipfs.ping(otherId, {count: 10, n: 10}, (err, res) => {
+        expect(err).to.exist()
+        done()
+      })
+    })
   })
 
   describe('promise API', () => {
@@ -126,11 +126,11 @@ describe('.ping',function () {
         .then((res) => {
           expect(res).to.be.an('array')
           expect(res).to.have.lengthOf(3)
-					res.forEach(packet => {
-						expect(packet).to.have.keys('Success', 'Time', 'Text')
-						expect(packet.Time).to.be.a('number')
-					})
-					const resultMsg = res.find(packet => packet.Text.includes('Average latency'))
+          res.forEach(packet => {
+            expect(packet).to.have.keys('Success', 'Time', 'Text')
+            expect(packet.Time).to.be.a('number')
+          })
+          const resultMsg = res.find(packet => packet.Text.includes('Average latency'))
           expect(resultMsg).to.exist()
         })
     })
@@ -140,11 +140,11 @@ describe('.ping',function () {
         .then((res) => {
           expect(res).to.be.an('array')
           expect(res).to.have.lengthOf(3)
-					res.forEach(packet => {
-						expect(packet).to.have.keys('Success', 'Time', 'Text')
-						expect(packet.Time).to.be.a('number')
-					})
-					const resultMsg = res.find(packet => packet.Text.includes('Average latency'))
+          res.forEach(packet => {
+            expect(packet).to.have.keys('Success', 'Time', 'Text')
+            expect(packet.Time).to.be.a('number')
+          })
+          const resultMsg = res.find(packet => packet.Text.includes('Average latency'))
           expect(resultMsg).to.exist()
         })
     })
@@ -154,11 +154,11 @@ describe('.ping',function () {
         .then((res) => {
           expect(res).to.be.an('array')
           expect(res).to.have.lengthOf(5)
-					res.forEach(packet => {
-						expect(packet).to.have.keys('Success', 'Time', 'Text')
-						expect(packet.Time).to.be.a('number')
-					})
-					const resultMsg = res.find(packet => packet.Text.includes('Average latency'))
+          res.forEach(packet => {
+            expect(packet).to.have.keys('Success', 'Time', 'Text')
+            expect(packet.Time).to.be.a('number')
+          })
+          const resultMsg = res.find(packet => packet.Text.includes('Average latency'))
           expect(resultMsg).to.exist()
         })
     })
@@ -167,136 +167,136 @@ describe('.ping',function () {
       ipfs.ping(otherId, {n: 3, count:3})
         .catch(err => {
           expect(err).to.exist()
-					done()
+          done()
         })
     })
   })
 
-	describe('pull stream API', () => {
-		it('ping another peer with the default packet count', (done) => {
-			pull(
-				ipfs.pingPullStream(otherId),
-				collect((err, data) => {
-					expect(err).to.not.exist()
+  describe('pull stream API', () => {
+    it('ping another peer with the default packet count', (done) => {
+      pull(
+        ipfs.pingPullStream(otherId),
+        collect((err, data) => {
+          expect(err).to.not.exist()
           expect(data).to.be.an('array')
           expect(data).to.have.lengthOf(3)
-					data.forEach(packet => {
-						expect(packet).to.have.keys('Success', 'Time', 'Text')
-						expect(packet.Time).to.be.a('number')
-					})
-					const resultMsg = data.find(packet => packet.Text.includes('Average latency'))
+          data.forEach(packet => {
+            expect(packet).to.have.keys('Success', 'Time', 'Text')
+            expect(packet.Time).to.be.a('number')
+          })
+          const resultMsg = data.find(packet => packet.Text.includes('Average latency'))
           expect(resultMsg).to.exist()
-					done()
-				})
-			)
-		})
+          done()
+        })
+      )
+    })
 
-		it('ping another peer with a specifc packet count through parameter count', (done) => {
-			pull(
-				ipfs.pingPullStream(otherId, {count: 3}),
-				collect((err, data) => {
-					expect(err).to.not.exist()
+    it('ping another peer with a specifc packet count through parameter count', (done) => {
+      pull(
+        ipfs.pingPullStream(otherId, {count: 3}),
+        collect((err, data) => {
+          expect(err).to.not.exist()
           expect(data).to.be.an('array')
           expect(data).to.have.lengthOf(5)
-					data.forEach(packet => {
-						expect(packet).to.have.keys('Success', 'Time', 'Text')
-						expect(packet.Time).to.be.a('number')
-					})
-					const resultMsg = data.find(packet => packet.Text.includes('Average latency'))
+          data.forEach(packet => {
+            expect(packet).to.have.keys('Success', 'Time', 'Text')
+            expect(packet.Time).to.be.a('number')
+          })
+          const resultMsg = data.find(packet => packet.Text.includes('Average latency'))
           expect(resultMsg).to.exist()
-					done()
-				})
-			)
-		})
+          done()
+        })
+      )
+    })
 
 
-		it('ping another peer with a specifc packet count through parameter n', (done) => {
-			pull(
-				ipfs.pingPullStream(otherId, {n: 3}),
-				collect((err, data) => {
-					expect(err).to.not.exist()
+    it('ping another peer with a specifc packet count through parameter n', (done) => {
+      pull(
+        ipfs.pingPullStream(otherId, {n: 3}),
+        collect((err, data) => {
+          expect(err).to.not.exist()
           expect(data).to.be.an('array')
           expect(data).to.have.lengthOf(5)
-					data.forEach(packet => {
-						expect(packet).to.have.keys('Success', 'Time', 'Text')
-						expect(packet.Time).to.be.a('number')
-					})
-					const resultMsg = data.find(packet => packet.Text.includes('Average latency'))
+          data.forEach(packet => {
+            expect(packet).to.have.keys('Success', 'Time', 'Text')
+            expect(packet.Time).to.be.a('number')
+          })
+          const resultMsg = data.find(packet => packet.Text.includes('Average latency'))
           expect(resultMsg).to.exist()
-					done()
-				})
-			)
-		})
+          done()
+        })
+      )
+    })
 
-		it('sending both n and count should fail', (done) => {
-			pull(
-				ipfs.pingPullStream(otherId, {n: 3, count: 3}),
-				collect(err => {
-					expect(err).to.exist()
-					done()
-				})
-			)
-		})
-	})
+    it('sending both n and count should fail', (done) => {
+      pull(
+        ipfs.pingPullStream(otherId, {n: 3, count: 3}),
+        collect(err => {
+          expect(err).to.exist()
+          done()
+        })
+      )
+    })
+  })
 
   describe('readable stream API', () => {
-		it('ping another peer with the default packet count', (done) => {
-			let packetNum = 0
-			ipfs.pingReadableStream(otherId)
-				.on('data', data => {
-					packetNum++
-					expect(data).to.be.an('object')
-					expect(data).to.have.keys('Success', 'Time', 'Text')
-				})
-				.on('error', err => {
-					expect(err).not.to.exist()
-				})
-				.on('end', () => {
-					expect(packetNum).to.equal(3)
-					done()
-				})
-		})
+    it('ping another peer with the default packet count', (done) => {
+      let packetNum = 0
+      ipfs.pingReadableStream(otherId)
+        .on('data', data => {
+          packetNum++
+          expect(data).to.be.an('object')
+          expect(data).to.have.keys('Success', 'Time', 'Text')
+        })
+        .on('error', err => {
+          expect(err).not.to.exist()
+        })
+        .on('end', () => {
+          expect(packetNum).to.equal(3)
+          done()
+        })
+    })
 
-		it('ping another peer with a specifc packet count through parameter count', (done) => {
-			let packetNum = 0
-			ipfs.pingReadableStream(otherId, {count: 3})
-				.on('data', data => {
-					packetNum++
-					expect(data).to.be.an('object')
-					expect(data).to.have.keys('Success', 'Time', 'Text')
-				})
-				.on('error', err => {
-					expect(err).not.to.exist()
-				})
-				.on('end', () => {
-					expect(packetNum).to.equal(5)
-					done()
-				})
-		})
+    it('ping another peer with a specifc packet count through parameter count', (done) => {
+      let packetNum = 0
+      ipfs.pingReadableStream(otherId, {count: 3})
+        .on('data', data => {
+          packetNum++
+          expect(data).to.be.an('object')
+          expect(data).to.have.keys('Success', 'Time', 'Text')
+        })
+        .on('error', err => {
+          expect(err).not.to.exist()
+        })
+        .on('end', () => {
+          expect(packetNum).to.equal(5)
+          done()
+        })
+    })
 
-		it('ping another peer with a specifc packet count through parameter n', (done) => {
-			let packetNum = 0
-			ipfs.pingReadableStream(otherId, {n: 3})
-				.on('data', data => {
-					packetNum++
-					expect(data).to.be.an('object')
-					expect(data).to.have.keys('Success', 'Time', 'Text')
-				})
-				.on('error', err => {
-					expect(err).not.to.exist()
-				})
-				.on('end', () => {
-					expect(packetNum).to.equal(5)
-					done()
-				})
-		})
+    it('ping another peer with a specifc packet count through parameter n', (done) => {
+      let packetNum = 0
+      ipfs.pingReadableStream(otherId, {n: 3})
+        .on('data', data => {
+          packetNum++
+          expect(data).to.be.an('object')
+          expect(data).to.have.keys('Success', 'Time', 'Text')
+        })
+        .on('error', err => {
+          expect(err).not.to.exist()
+        })
+        .on('end', () => {
+          expect(packetNum).to.equal(5)
+          done()
+        })
+    })
 
-		it('sending both n and count should fail', (done) => {
-			ipfs.pingReadableStream(otherId, {n: 3, count:3})
-				.on('error', err => {
-					expect(err).to.exist()
-					done()
-				})
-		})
-	})
+    it('sending both n and count should fail', (done) => {
+      ipfs.pingReadableStream(otherId, {n: 3, count:3})
+        .on('error', err => {
+          expect(err).to.exist()
+          done()
+        })
+    })
+  })
 })

--- a/test/ping.spec.js
+++ b/test/ping.spec.js
@@ -12,7 +12,7 @@ const series = require('async/series')
 const IPFSApi = require('../src')
 const f = require('./utils/factory')
 
-describe.skip('.ping', () => {
+describe.only('.ping', () => {
   let ipfs
   let ipfsd
   let other
@@ -43,7 +43,7 @@ describe.skip('.ping', () => {
         ipfsd.api.id((err, id) => {
           expect(err).to.not.exist()
           const ma = id.addresses[0]
-          other.api.swarm.connect(ma, cb)
+          other.swarm.connect(ma, cb)
         })
       }
     ], done)
@@ -63,11 +63,14 @@ describe.skip('.ping', () => {
 
         ipfs.ping(id.id, (err, res) => {
           expect(err).to.not.exist()
-          expect(res).to.have.a.property('Success')
-          expect(res).to.have.a.property('Time')
-          expect(res).to.have.a.property('Text')
-          expect(res.Text).to.contain('Average latency')
-          expect(res.Time).to.be.a('number')
+          expect(res).to.be.an('array')
+          expect(res).to.have.lengthOf(3)
+					res.forEach(packet => {
+						expect(packet).to.have.keys('Success', 'Time', 'Text')
+						expect(packet.Time).to.be.a('number')
+					})
+					const resultMsg = res.find(packet => packet.Text.includes('Average latency'))
+          expect(resultMsg).to.exist()
           done()
         })
       })
@@ -81,11 +84,14 @@ describe.skip('.ping', () => {
           return ipfs.ping(id.id)
         })
         .then((res) => {
-          expect(res).to.have.a.property('Success')
-          expect(res).to.have.a.property('Time')
-          expect(res).to.have.a.property('Text')
-          expect(res.Text).to.contain('Average latency')
-          expect(res.Time).to.be.a('number')
+          expect(res).to.be.an('array')
+          expect(res).to.have.lengthOf(3)
+					res.forEach(packet => {
+						expect(packet).to.have.keys('Success', 'Time', 'Text')
+						expect(packet.Time).to.be.a('number')
+					})
+					const resultMsg = res.find(packet => packet.Text.includes('Average latency'))
+          expect(resultMsg).to.exist()
         })
     })
   })

--- a/test/sub-modules.spec.js
+++ b/test/sub-modules.spec.js
@@ -69,8 +69,12 @@ describe('submodules', () => {
 
   it('ping', () => {
     const ping = require('../src/ping')(config)
+    const pingPullStream = require('../src/ping-pull-stream')(config)
+    const pingReadableStream = require('../src/ping-readable-stream')(config)
 
     expect(ping).to.be.a('function')
+    expect(pingPullStream ).to.be.a('function')
+    expect(pingReadableStream ).to.be.a('function')
   })
 
   it('log', () => {

--- a/test/sub-modules.spec.js
+++ b/test/sub-modules.spec.js
@@ -73,8 +73,8 @@ describe('submodules', () => {
     const pingReadableStream = require('../src/ping-readable-stream')(config)
 
     expect(ping).to.be.a('function')
-    expect(pingPullStream ).to.be.a('function')
-    expect(pingReadableStream ).to.be.a('function')
+    expect(pingPullStream).to.be.a('function')
+    expect(pingReadableStream).to.be.a('function')
   })
 
   it('log', () => {


### PR DESCRIPTION
This should close #556 and add two additional methods to stream the ping results.