### PR TITLE
feat: add awareness of wrapWithDirectory option to utils/send-files-stream

### DIFF
--- a/src/utils/send-files-stream.js
+++ b/src/utils/send-files-stream.js
@@ -79,6 +79,7 @@ module.exports = (send, path) => {
     qs['raw-leaves'] = propOrProp(options, 'raw-leaves', 'rawLeaves')
     qs['only-hash'] = propOrProp(options, 'only-hash', 'onlyHash')
     qs.hash = propOrProp(options, 'hash', 'hashAlg')
+    qs['wrap-with-directory'] = propOrProp(options, 'wrap-with-directory', 'wrapWithDirectory')
 
     const args = {
       path: path,


### PR DESCRIPTION
For https://github.com/ipfs/js-ipfs/issues/1178

Adds awareness of new wrapWithDirectory parameter which will be passed along to the api via querystring.