### PR TITLE
Add authorization header config option

### DIFF
--- a/src/utils/send-request.js
+++ b/src/utils/send-request.js
@@ -108,6 +108,10 @@ function requestAPI (config, options, callback) {
   const method = 'POST'
   const headers = {}
 
+  if (config.authorization) {
+    headers['Authorization'] = config.authorization
+  }
+
   if (isNode) {
     // Browsers do not allow you to modify the user agent
     headers['User-Agent'] = config['user-agent']


### PR DESCRIPTION
One potential solution for #724, allowing for clients to optionally send an `Authorization` header. This would allow an API gateway to authenticate each request before proxying it to an IPFS daemon.