### PR TITLE
Fix link to interface tests in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ This relies on a global `Promise` object. If you are in an environment where tha
 
 ### Testing
 
-We run tests by executing `npm test` in a terminal window. This will run both Node.js and Browser tests, both in Chrome and PhantomJS. To ensure that the module conforms with the [`interface-ipfs-core`](https://github.com/ipfs/interface-ipfs-core) spec, we run the batch of tests provided by the interface module, which can be found [here](https://github.com/ipfs/interface-ipfs-core/tree/master/src).
+We run tests by executing `npm test` in a terminal window. This will run both Node.js and Browser tests, both in Chrome and PhantomJS. To ensure that the module conforms with the [`interface-ipfs-core`](https://github.com/ipfs/interface-ipfs-core) spec, we run the batch of tests provided by the interface module, which can be found [here](https://github.com/ipfs/interface-ipfs-core/tree/master/js/src).
 
 ## Contribute
 


### PR DESCRIPTION
Updates link in readme
- ~~https://github.com/ipfs/interface-ipfs-core/tree/master/src~~
- https://github.com/ipfs/interface-ipfs-core/tree/master/js/src