### PR TITLE
Fix #140: ipfs add url wrap doesn't work

### DIFF
--- a/src/util/url-add.js
+++ b/src/util/url-add.js
@@ -35,7 +35,9 @@ module.exports = (send) => {
 const validUrl = (url) => typeof url === 'string' && url.startsWith('http')
 
 const requestWithRedirect = (url, opts, sendOneFile, callback) => {
-  const req = request(parseUrl(url).protocol)(url, (res) => {
+  const parsedUrl = parseUrl(url)
+
+  const req = request(parsedUrl.protocol)(url, (res) => {
     if (res.statusCode >= 400) {
       return callback(new Error(`Failed to download with ${res.statusCode}`))
     }
@@ -46,13 +48,18 @@ const requestWithRedirect = (url, opts, sendOneFile, callback) => {
       if (!validUrl(redirection)) {
         return callback(new Error('redirection url must be an http(s) url'))
       }
+
       requestWithRedirect(redirection, opts, sendOneFile, callback)
     } else {
       const requestOpts = {
         qs: opts,
         converter: FileResultStreamConverter
       }
-      sendOneFile(res, requestOpts, callback)
+
+      sendOneFile({
+        content: res,
+        path: parsedUrl.pathname.split('/').pop()
+      }, requestOpts, callback)
     }
   })
 

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -165,6 +165,7 @@ describe('.util', () => {
         expect(result[0].path).to.equal('969165.jpg')
         expect(result[1].hash).to.equal('QmWjppACLcFLQ2qL38unKQvJBhXH3RUtcGLPk7zmrTwV61')
         expect(result.length).to.equal(2)
+        done()
       })
     })
 

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -156,6 +156,18 @@ describe('.util', () => {
         .then(out => expectTimeout(ipfs.object.get(out[0].hash), 4000))
     })
 
+    it('with wrap-with-directory=true', (done) => {
+      ipfs.util.addFromURL('http://ipfs.io/ipfs/QmWjppACLcFLQ2qL38unKQvJBhXH3RUtcGLPk7zmrTwV61/969165.jpg', {
+        wrapWithDirectory: true
+      }, (err, result) => {
+        expect(err).to.not.exist()
+        expect(result[0].hash).to.equal('QmaL9zy7YUfvWmtD5ZXp42buP7P4xmZJWFkm78p8FJqgjg')
+        expect(result[0].path).to.equal('969165.jpg')
+        expect(result[1].hash).to.equal('QmWjppACLcFLQ2qL38unKQvJBhXH3RUtcGLPk7zmrTwV61')
+        expect(result.length).to.equal(2)
+      })
+    })
+
     it('with invalid url', function (done) {
       ipfs.util.addFromURL('http://invalid', (err, result) => {
         expect(err.code).to.equal('ENOTFOUND')


### PR DESCRIPTION
`ipfs.util.addFromURL` now works well with the `wrapWithDirectory` option.