### PR TITLE
fix: do not fail stop node if failed start node

### DIFF
--- a/test/bitswap.spec.js
+++ b/test/bitswap.spec.js
@@ -27,7 +27,10 @@ describe('.bitswap', function () {
     })
   })
 
-  after((done) => ipfsd.stop(done))
+  after((done) => {
+    if (!ipfsd) return done()
+    ipfsd.stop(done)
+  })
 
   it('.wantlist', (done) => {
     ipfs.bitswap.wantlist((err, res) => {

--- a/test/commands.spec.js
+++ b/test/commands.spec.js
@@ -25,7 +25,10 @@ describe('.commands', function () {
     })
   })
 
-  after((done) => ipfsd.stop(done))
+  after((done) => {
+    if (!ipfsd) return done()
+    ipfsd.stop(done)
+  })
 
   it('lists commands', (done) => {
     ipfs.commands((err, res) => {

--- a/test/constructor.spec.js
+++ b/test/constructor.spec.js
@@ -35,7 +35,10 @@ describe('ipfs-api constructor tests', () => {
       })
     })
 
-    after((done) => ipfsd.stop(done))
+    after((done) => {
+      if (!ipfsd) return done()
+      ipfsd.stop(done)
+    })
 
     it('opts', (done) => {
       const splitted = apiAddr.split('/')

--- a/test/diag.spec.js
+++ b/test/diag.spec.js
@@ -28,7 +28,10 @@ describe('.diag', function () {
     })
   })
 
-  after((done) => ipfsd.stop(done))
+  after((done) => {
+    if (!ipfsd) return done()
+    ipfsd.stop(done)
+  })
 
   describe('Callback API', () => {
     // Disabled in go-ipfs 0.4.10

--- a/test/files.spec.js
+++ b/test/files.spec.js
@@ -47,7 +47,10 @@ describe('.files (the MFS API part)', function () {
     })
   })
 
-  after((done) => ipfsd.stop(done))
+  after((done) => {
+    if (!ipfsd) return done()
+    ipfsd.stop(done)
+  })
 
   it('add file for testing', (done) => {
     ipfs.files.add(testfile, (err, res) => {

--- a/test/get.spec.js
+++ b/test/get.spec.js
@@ -41,7 +41,10 @@ describe('.get (specific go-ipfs features)', function () {
     ], done)
   })
 
-  after((done) => ipfsd.stop(done))
+  after((done) => {
+    if (!ipfsd) return done()
+    ipfsd.stop(done)
+  })
 
   it('no compression args', (done) => {
     ipfs.get(smallFile.cid, (err, files) => {

--- a/test/key.spec.js
+++ b/test/key.spec.js
@@ -25,7 +25,10 @@ describe('.key', function () {
     })
   })
 
-  after((done) => ipfsd.stop(done))
+  after((done) => {
+    if (!ipfsd) return done()
+    ipfsd.stop(done)
+  })
 
   describe('Callback API', () => {
     describe('.gen', () => {

--- a/test/log.spec.js
+++ b/test/log.spec.js
@@ -25,7 +25,10 @@ describe('.log', function () {
     })
   })
 
-  after((done) => ipfsd.stop(done))
+  after((done) => {
+    if (!ipfsd) return done()
+    ipfsd.stop(done)
+  })
 
   it('.log.tail', (done) => {
     const req = ipfs.log.tail((err, res) => {

--- a/test/name.spec.js
+++ b/test/name.spec.js
@@ -62,8 +62,14 @@ describe('.name', () => {
 
   after((done) => {
     parallel([
-      (cb) => ipfsd.stop(cb),
-      (cb) => otherd.stop(cb)
+      (cb) => {
+        if (!ipfsd) return cb()
+        ipfsd.stop(cb)
+      },
+      (cb) => {
+        if (!otherd) return cb()
+        otherd.stop(cb)
+      }
     ], done)
   })
 

--- a/test/ping.spec.js
+++ b/test/ping.spec.js
@@ -60,8 +60,14 @@ describe('.ping', function () {
 
   after((done) => {
     parallel([
-      (cb) => ipfsd.stop(cb),
-      (cb) => otherd.stop(cb)
+      (cb) => {
+        if (!ipfsd) return cb()
+        ipfsd.stop(cb)
+      },
+      (cb) => {
+        if (!otherd) return cb()
+        otherd.stop(cb)
+      }
     ], done)
   })
 

--- a/test/pubsub-in-browser.spec.js
+++ b/test/pubsub-in-browser.spec.js
@@ -55,7 +55,10 @@ describe('.pubsub is not supported in the browser, yet!', function () {
     })
   })
 
-  after((done) => ipfsd.stop(done))
+  after((done) => {
+    if (!ipfsd) return done()
+    ipfsd.stop(done)
+  })
 
   describe('everything errors', () => {
     describe('Callback API', () => {

--- a/test/refs.spec.js
+++ b/test/refs.spec.js
@@ -49,7 +49,10 @@ describe('.refs', function () {
     ], done)
   })
 
-  after((done) => ipfsd.stop(done))
+  after((done) => {
+    if (!ipfsd) return done()
+    ipfsd.stop(done)
+  })
 
   const result = [
     {

--- a/test/repo.spec.js
+++ b/test/repo.spec.js
@@ -24,7 +24,10 @@ describe('.repo', function () {
     })
   })
 
-  after((done) => ipfsd.stop(done))
+  after((done) => {
+    if (!ipfsd) return done()
+    ipfsd.stop(done)
+  })
 
   it('.repo.gc', (done) => {
     ipfs.repo.gc((err, res) => {

--- a/test/stats.spec.js
+++ b/test/stats.spec.js
@@ -24,7 +24,10 @@ describe('stats', function () {
     })
   })
 
-  after((done) => ipfsd.stop(done))
+  after((done) => {
+    if (!ipfsd) return done()
+    ipfsd.stop(done)
+  })
 
   it('.stats.bitswap', (done) => {
     ipfs.stats.bitswap((err, res) => {

--- a/test/types.spec.js
+++ b/test/types.spec.js
@@ -34,7 +34,10 @@ describe('.types', function () {
     })
   })
 
-  after((done) => ipfsd.stop(done))
+  after((done) => {
+    if (!ipfsd) return done()
+    ipfsd.stop(done)
+  })
 
   it('types object', () => {
     expect(ipfs.types).to.be.deep.equal({

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -32,7 +32,10 @@ describe('.util', () => {
     })
   })
 
-  after((done) => ipfsd.stop(done))
+  after((done) => {
+    if (!ipfsd) return done()
+    ipfsd.stop(done)
+  })
 
   it('.streamAdd', (done) => {
     const tfpath = path.join(__dirname, '/fixtures/testfile.txt')


### PR DESCRIPTION
If failed start node in `before`, do not fail stop node in `after`.

It reduces the noise from IPFS node start failures by fixing the after hook so it doesn't also error when trying to stop a node that didn't start.

e.g.

```
  4) .refs "before all" hook:
     Uncaught AssertionError: expected [Error: connect ECONNREFUSED 127.0.0.1:53477] to not exist
      at ipfsd.api.id (test\ping.spec.js:47:30)
      at send (node_modules\ipfsd-ctl\node_modules\ipfs-api\src\id.js:19:16)
      at f (node_modules\once\once.js:25:25)
      at ClientRequest.req.on (node_modules\ipfsd-ctl\node_modules\ipfs-api\src\utils\send-request.js:168:5)
      at Socket.socketErrorListener (_http_client.js:387:9)
      at emitErrorNT (internal/streams/destroy.js:64:8)
      at _combinedTickCallback (internal/process/next_tick.js:138:11)
      at process._tickCallback (internal/process/next_tick.js:180:9)
```

This PR stops us from also receiving this noise:

```
  5) .refs "after all" hook:
     TypeError: Cannot read property 'stop' of undefined
      at Context.after (test\refs.spec.js:52:25)
```