### PR TITLE
chore: use tildes for pre-v1 deps

### DIFF
--- a/examples/bundle-browserify/package.json
+++ b/examples/bundle-browserify/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "browserify": "^13.1.1",
     "ipfs-api": "^11.1.0",
-    "http-server": "^0.9.0"
+    "http-server": "~0.9.0"
   },
   "dependencies": {
   }

--- a/examples/bundle-webpack/package.json
+++ b/examples/bundle-webpack/package.json
@@ -12,8 +12,8 @@
     "babel-core": "^5.4.7",
     "babel-loader": "^5.1.2",
     "ipfs-api": "^11.1.0",
-    "json-loader": "^0.5.3",
-    "react": "^0.13.0",
+    "json-loader": "~0.5.3",
+    "react": "~0.13.0",
     "react-hot-loader": "^1.3.0",
     "webpack": "^1.9.6",
     "webpack-dev-server": "^1.8.2"

--- a/examples/name-api/package.json
+++ b/examples/name-api/package.json
@@ -10,6 +10,6 @@
   "license": "MIT",
   "devDependencies": {
     "browserify": "^14.4.0",
-    "http-server": "^0.10.0"
+    "http-server": "~0.10.0"
   }
 }

--- a/examples/sub-module/package.json
+++ b/examples/sub-module/package.json
@@ -11,7 +11,7 @@
     "babel-core": "^6.25.0",
     "babel-loader": "^7.1.0",
     "babel-preset-env": "^1.5.2",
-    "babili": "^0.1.4",
+    "babili": "~0.1.4",
     "webpack": "^3.0.0"
   }
 }

--- a/examples/upload-file-via-browser/package.json
+++ b/examples/upload-file-via-browser/package.json
@@ -14,7 +14,7 @@
     "babel-core": "^5.4.7",
     "babel-loader": "^5.1.2",
     "ipfs-api": "../../",
-    "json-loader": "^0.5.4",
+    "json-loader": "~0.5.4",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-hot-loader": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "is-ipfs": "~0.3.2",
     "is-pull-stream": "0.0.0",
     "is-stream": "^1.1.0",
-    "libp2p-crypto": "^0.13.0",
+    "libp2p-crypto": "~0.13.0",
     "lru-cache": "^4.1.3",
     "multiaddr": "^5.0.0",
     "multibase": "~0.4.0",
@@ -51,7 +51,7 @@
     "peer-id": "~0.10.7",
     "peer-info": "~0.14.1",
     "promisify-es6": "^1.0.3",
-    "pull-defer": "^0.2.2",
+    "pull-defer": "~0.2.2",
     "pull-pushable": "^2.2.0",
     "pull-stream-to-stream": "^1.3.4",
     "pump": "^3.0.0",
@@ -59,7 +59,7 @@
     "readable-stream": "^2.3.6",
     "stream-http": "^2.8.2",
     "stream-to-pull-stream": "^1.7.2",
-    "streamifier": "^0.1.1",
+    "streamifier": "~0.1.1",
     "tar-stream": "^1.6.1"
   },
   "engines": {


### PR DESCRIPTION
> Our rule is: Use ~ for everything below 1.0.0 and ^ for everything above 1.0.0. If you find a package.json that is not following this rule, please submit a PR.

https://github.com/ipfs/community/blob/master/js-code-guidelines.md#dependency-versions