### PR TITLE
fix: increase timeout for ping tests

### DIFF
--- a/test/ping.spec.js
+++ b/test/ping.spec.js
@@ -21,6 +21,8 @@ function isPong (pingResponse) {
 }
 
 describe('.ping', function () {
+  this.timeout(10 * 1000)
+
   let ipfs
   let ipfsd
   let other


### PR DESCRIPTION
These have been observed to take a little over the default 2s in web browsers/workers so are intermittently failing on CI and locally.