### PR TITLE
fix: configure webpack to not use esmodules in dependencies

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -5,6 +5,11 @@ const createServer = require('ipfsd-ctl').createServer
 const server = createServer()
 
 module.exports = {
+  webpack: {
+    resolve: {
+      mainFields: ['browser', 'main']
+    }
+  },
   karma: {
     files: [{
       pattern: 'node_modules/interface-ipfs-core/js/test/fixtures/**/*',


### PR DESCRIPTION
Big.js just released an update that added esmodule support by adding a "module" field to their package.json. By default, webpack will use this field when requiring a module. Since esmodules aren't fully supported in the browser and we don't do any transpiling this PR configures webpack to not consider the esmodule field.

[Webpack `mainFields` docs](https://webpack.js.org/configuration/resolve/#resolve-mainfields)

[Why `require('big.js')` is broken for us](https://github.com/webpack/webpack/issues/4742)

Refs https://github.com/ipfs/js-ipfs/issues/1363

Note that this solves the issue for `big.js`, but also for any other modules in the future that decide to define a `module` field in their `package.json` or any that already do and we just haven't realised it yet!