### PR TITLE
fix: correctly differentiate pong responses

### DIFF
--- a/test/ping.spec.js
+++ b/test/ping.spec.js
@@ -17,7 +17,7 @@ const f = require('./utils/factory')
 
 // Determine if a ping response object is a pong, or something else, like a status message
 function isPong (pingResponse) {
-  return Boolean(pingResponse && pingResponse.time)
+  return Boolean(pingResponse && pingResponse.success && !pingResponse.text)
 }
 
 describe('.ping', function () {


### PR DESCRIPTION
Investigation discovered that pong responses CAN have `time: 0` (they can be very quick). Previously pong messages were differentiated by time greater than 0, but considering it can be 0 this was incorrect.

<img width="436" alt="screen shot 2018-05-24 at 19 51 43" src="https://user-images.githubusercontent.com/152863/40509903-d065fc8c-5f92-11e8-8c18-2429c367cf8b.png">