### PR TITLE
Fix for empty data in block.

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "eslint-plugin-react": "^7.9.1",
     "go-ipfs-dep": "~0.4.15",
     "gulp": "^3.9.1",
-    "interface-ipfs-core": "~0.68.1",
+    "interface-ipfs-core": "~0.69.0",
     "ipfsd-ctl": "~0.37.3",
     "pull-stream": "^3.6.8",
     "socket.io": "^2.1.1",

--- a/src/block/get.js
+++ b/src/block/get.js
@@ -39,6 +39,7 @@ module.exports = (send) => {
           if (err) {
             return callback(err)
           }
+          if (!data.length) data = Buffer.alloc(0)
           callback(null, new Block(data, cid))
         })
       }

--- a/src/block/get.js
+++ b/src/block/get.js
@@ -34,11 +34,17 @@ module.exports = (send) => {
     const transform = (res, callback) => {
       if (Buffer.isBuffer(res)) {
         callback(null, new Block(res, cid))
+      // For empty blocks, concat-stream can't infer the encoding so we are
+      // passed back an empty array
+      } else if (Array.isArray(res) && res.length === 0) {
+        callback(null, new Block(Buffer.alloc(0), cid))
       } else {
         streamToValue(res, (err, data) => {
           if (err) {
             return callback(err)
           }
+          // For empty blocks, concat-stream can't infer the encoding so we are
+          // passed back an empty array
           if (!data.length) data = Buffer.alloc(0)
           callback(null, new Block(data, cid))
         })


### PR DESCRIPTION
Found this very strange bug when creating DAGNode's with empty buffers for data.

streamToValue returns an empty array when the data is empty, which down the line triggers an exception in ipfs-block because this sends an empty array instead of a buffer.