### PR TITLE
fix: block.put() options

### DIFF
--- a/src/block/put.js
+++ b/src/block/put.js
@@ -5,15 +5,16 @@ const Block = require('ipfs-block')
 const CID = require('cids')
 const once = require('once')
 const SendOneFile = require('../utils/send-one-file')
+const multihashes = require('multihashes')
 
 module.exports = (send) => {
   const sendOneFile = SendOneFile(send, 'block/put')
 
-  return promisify((block, cid, _callback) => {
+  return promisify((block, opts, _callback) => {
     // TODO this needs to be adjusted with the new go-ipfs http-api
-    if (typeof cid === 'function') {
-      _callback = cid
-      cid = {}
+    if (typeof opts === 'function') {
+      _callback = opts
+      opts = {}
     }
 
     const callback = once(_callback)
@@ -22,16 +23,39 @@ module.exports = (send) => {
       return callback(new Error('block.put accepts only one block'))
     }
 
+    let cid = opts.cid
+
     if (typeof block === 'object' && block.data) {
+      if (block.cid) cid = block.cid
       block = block.data
     }
 
-    sendOneFile(block, {}, (err, result) => {
+    let qs = Object.assign(opts,
+      {'input-enc': 'raw',
+       hashAlg: opts.mhtype || 'sha2-256'
+      }
+    )
+
+    if (cid && CID.isCID(cid)) {
+      qs.format = cid.codec
+      qs.hashAlg = multihashes.decode(cid.multihash).name
+    }
+    delete qs.cid
+
+    let _send = sendOneFile
+
+    console.error(qs)
+
+    if (qs.format && qs.format.startsWith('dag-')) {
+      _send = SendOneFile(send, 'dag/put')
+    }
+
+    _send(block, {qs}, (err, result) => {
       if (err) {
         return callback(err) // early
       }
-
-      callback(null, new Block(block, new CID(result.Key)))
+      let cid = result.Key || result.Cid['/']
+      callback(null, new Block(block, new CID(cid)))
     })
   })
 }

--- a/src/block/put.js
+++ b/src/block/put.js
@@ -30,11 +30,10 @@ module.exports = (send) => {
       block = block.data
     }
 
-    let qs = Object.assign(opts,
-      {'input-enc': 'raw',
-       hashAlg: opts.mhtype || 'sha2-256'
-      }
-    )
+    let qs = Object.assign(opts, {
+      'input-enc': 'raw',
+      hashAlg: opts.mhtype || 'sha2-256'
+    })
 
     if (cid && CID.isCID(cid)) {
       qs.format = cid.codec
@@ -43,8 +42,6 @@ module.exports = (send) => {
     delete qs.cid
 
     let _send = sendOneFile
-
-    console.error(qs)
 
     if (qs.format && qs.format.startsWith('dag-')) {
       _send = SendOneFile(send, 'dag/put')


### PR DESCRIPTION
So, this contains numerous fixes to block.put() some of which break the current tests because the tests are actually broken.

Prior to this patch, options passed in were simply ignored. The tests for those options showed false positives because the tests are passing in the default encoding values (dag-pb, sha2-256).

However, go-ipfs currently fails when trying to use `/block/put` for a dag node, you have to use `/dag/put` instead. So, I modified our `block.put()` API to check the format and call the dag put API instead, this is actually a good thing since the JS API for `dag.put()` does encoding for you which means adding this support to `block.put()` allows you to write already encoded dag nodes (which happens to be something I need anyway).

And now 3 tests are failing because those tests don't actually write a valid `dag-pb` node, they're just random junk buffers, and `/dag/put` actually validates them :)

I'll try to get around to fixing the tests and maybe writing a few extras as there's a few new features in here too (when you pass a Block instance it will use the attached cid, so you don't need to pass it in separately). But I won't get to that until next week and I wanted to get some eyeballs on this first.