### PR TITLE
feat: added resolve command

### DIFF
--- a/src/resolve.js
+++ b/src/resolve.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const promisify = require('promisify-es6')
+
+const transform = function (res, callback) {
+  callback(null, res.Path)
+}
+
+module.exports = (send) => {
+  return promisify((args, opts, callback) => {
+    if (typeof (opts) === 'function') {
+      callback = opts
+      opts = {}
+    }
+
+    send.andTransform({
+      path: 'resolve',
+      args: args,
+      qs: opts
+    }, transform, callback)
+  })
+}

--- a/src/utils/load-commands.js
+++ b/src/utils/load-commands.js
@@ -43,6 +43,7 @@ function requireCommands () {
     update: require('../update'),
     version: require('../version'),
     types: require('../types'),
+    resolve: require('../resolve'),
     dns: require('../dns')
   }
 


### PR DESCRIPTION
- js-ipfs-api is lacking the `ipfs resolve` command.
- it is also lacking in the ipfs/specs/core-api docs.
- but `ipfs resolve` has been an intended command for a long time