### PR TITLE
fix: config.set should reject buffer values

### DIFF
--- a/src/config/set.js
+++ b/src/config/set.js
@@ -12,9 +12,7 @@ module.exports = (send) => {
       return callback(new Error('Invalid key type'))
     }
 
-    if (typeof value !== 'object' &&
-      typeof value !== 'boolean' &&
-      typeof value !== 'string') {
+    if (value === undefined || Buffer.isBuffer(value)) {
       return callback(new Error('Invalid value type'))
     }
 


### PR DESCRIPTION
`config.set` should be rejecting buffer values[0]. Currently it accepts them because a buffer returns `typeof` of `object`, and is serialized into an object `{type: 'buffer', data: [...]}`.

This change brings the type checking of the `value` field inline with the `js-ipfs-repo`[1].

More info: https://github.com/ipfs/interface-ipfs-core/issues/320

[0] https://github.com/ipfs/interface-ipfs-core/blob/ef910266b36c89fe21f9821f86bdb9955d60b468/js/src/config/set.js#L82-L87
[1] https://github.com/ipfs/js-ipfs-repo/blob/a7ea45bac6f1c264f86e79357f702314758a48f1/src/config.js#L65-L67