### PR TITLE
chore: ignore response body for some mfs commands

### DIFF
--- a/src/files/cp.js
+++ b/src/files/cp.js
@@ -15,6 +15,6 @@ module.exports = (send) => {
       path: 'files/cp',
       args: sources,
       qs: opts
-    }, callback)
+    }, (error) => callback(error))
   })
 }

--- a/src/files/flush.js
+++ b/src/files/flush.js
@@ -12,6 +12,6 @@ module.exports = (send) => {
     return send({
       path: 'files/flush',
       args: args
-    }, callback)
+    }, (error) => callback(error))
   })
 }

--- a/src/files/mkdir.js
+++ b/src/files/mkdir.js
@@ -13,6 +13,6 @@ module.exports = (send) => {
       path: 'files/mkdir',
       args: args,
       qs: opts
-    }, callback)
+    }, (error) => callback(error))
   })
 }

--- a/src/files/mv.js
+++ b/src/files/mv.js
@@ -15,6 +15,6 @@ module.exports = (send) => {
       path: 'files/mv',
       args: sources,
       qs: opts
-    }, callback)
+    }, (error) => callback(error))
   })
 }

--- a/src/files/rm.js
+++ b/src/files/rm.js
@@ -22,6 +22,6 @@ module.exports = (send) => {
       path: 'files/rm',
       args: path,
       qs: opts
-    }, callback)
+    }, (error) => callback(error))
   })
 }


### PR DESCRIPTION
Most of the mfs commands have no response body but our client returns the response object that then has a stream which resolves to an empty string.  This causes problems with the interop tests as you can't easily compare the two response objects so we should probably just ignore the response of any method we know will either return an error or nothing at all.

Also makes invocations over http consistent with invoking core directly.