### PR TITLE
Fix Request logging broken in Electron

### DIFF
--- a/src/utils/send-request.js
+++ b/src/utils/send-request.js
@@ -37,7 +37,7 @@ function onRes (buffer, cb) {
     const isJson = res.headers['content-type'] &&
                    res.headers['content-type'].indexOf('application/json') === 0
 
-    if (isNode) {
+    if (res.req) {
       log(res.req.method, `${res.req.getHeaders().host}${res.req.path}`, res.statusCode, res.statusMessage)
     } else {
       log(res.url, res.statusCode, res.statusMessage)


### PR DESCRIPTION
When ipfs-api runs inside Electron, isNode is true, but res.req is undefined. And the request logging is breaks the lib.

It will be better to check whether res.req is set instead of relying on detect-node.

fixes #807