### PR TITLE
fix: increase name after timeout

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -17,7 +17,7 @@ module.exports = {
       served: true,
       included: false
     }],
-    browserNoActivityTimeout: 150 * 1000,
+    browserNoActivityTimeout: 210 * 1000,
     singleRun: true
   },
   hooks: {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "eslint-plugin-react": "^7.10.0",
     "go-ipfs-dep": "~0.4.15",
     "gulp": "^3.9.1",
-    "interface-ipfs-core": "~0.71.0",
+    "interface-ipfs-core": "~0.72.1",
     "ipfsd-ctl": "~0.37.5",
     "pull-stream": "^3.6.8",
     "socket.io": "^2.1.1",

--- a/test/name.spec.js
+++ b/test/name.spec.js
@@ -64,7 +64,9 @@ describe('.name', () => {
     ], done)
   })
 
-  after((done) => {
+  after(function (done) {
+    this.timeout(10 * 1000)
+
     parallel([
       (cb) => {
         if (!ipfsd) return cb()


### PR DESCRIPTION
Seeing this timeout on multiple environments and Node.js versions so have given it an extra 5s.

Also increases the `browserNoActivityTimeout` to give the `dht.query` test time to [fail but pass anyway](https://github.com/ipfs/interface-ipfs-core/blob/87a8f96b74987ab6d477dc73a91d9f32ff066267/js/src/dht/query.js#L46-L52) - previously the `browserNoActivityTimeout` wasn't taking into account the extra 60s allocated to the before hook, so I just added it here.