### PR TITLE
[WIP] add missing dag.tree()

### DIFF
--- a/src/dag/index.js
+++ b/src/dag/index.js
@@ -7,6 +7,7 @@ module.exports = (arg) => {
 
   return {
     get: require('./get')(send),
-    put: require('./put')(send)
+    put: require('./put')(send),
+    tree: require('./tree')(send)
   }
 }

--- a/src/dag/tree.js
+++ b/src/dag/tree.js
@@ -1,0 +1,37 @@
+'use strict'
+const promisify = require('promisify-es6')
+const block = require('../block')
+
+const DAGFormats = {
+  'dag-cbor': require('ipld-dag-cbor'),
+  'dag-pb': require('ipld-dag-pb')
+}
+
+module.exports = (send) => {
+  return promisify((cid, path, options, callback) => {
+    if (typeof path === 'function') {
+      callback = path
+      path = undefined
+    }
+
+    if (typeof options === 'function') {
+      callback = options
+      options = {}
+    }
+
+    options = options || {}
+    path = path || ''
+
+    // FIXME: handle case when options.recursive is true
+    block(send).get(cid, options, (err, ipfsBlock) => {
+      if (err) return callback(err, null)
+
+      let codec = ipfsBlock.cid.codec
+      if (codec in DAGFormats) {
+        DAGFormats[codec].resolver.tree(ipfsBlock.data, callback)
+      } else {
+        callback(new Error(`codec ${codec} is not valid`), null)
+      }
+    })
+  })
+}

--- a/test/dag.spec.js
+++ b/test/dag.spec.js
@@ -1,0 +1,77 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(dirtyChai)
+
+const IPFSApi = require('../src')
+const f = require('./utils/factory')
+
+describe('.dag', function () {
+  this.timeout(50 * 1000) // slow CI
+
+  let ipfs
+  let ipfsd
+
+  const obj = {
+    a: 1,
+    b: [1, 2, 3],
+    c: {
+      ca: [5, 6, 7],
+      cb: 'foo'
+    }
+  }
+
+  before((done) => {
+    f.spawn({ initOptions: { bits: 1024 } }, (err, _ipfsd) => {
+      expect(err).to.not.exist()
+      ipfsd = _ipfsd
+      ipfs = IPFSApi(_ipfsd.apiAddr)
+      done()
+    })
+  })
+
+  after((done) => {
+    if (!ipfsd) return done()
+    ipfsd.stop(done)
+  })
+
+  it('.dag.tree', (done) => {
+    const expectedPaths = [
+      'a', 'b', 'b/0', 'b/1', 'b/2', 'c', 'c/ca',
+      'c/ca/0', 'c/ca/1', 'c/ca/2', 'c/cb'
+    ]
+
+    ipfs.dag.put(obj, (err, cid) => {
+      expect(err).to.not.exist()
+      ipfs.dag.tree(cid, {}, (err, paths) => {
+        expect(err).to.not.exist()
+        expect(paths).deep.equal(expectedPaths)
+        done()
+      })
+    })
+  })
+
+  it('.dag.put', (done) => {
+    let expectedCidStr = 'zdpuArMWc9Ee3B7zUDucRjvA1bDgYpWt8rpUXXjY3tbmBw619'
+    ipfs.dag.put(obj, (err, cid) => {
+      expect(err).to.not.exist()
+      let cidStr = cid.toBaseEncodedString()
+      expect(cidStr).to.be.equal(expectedCidStr)
+      done()
+    })
+  })
+
+  it('.dag.get', (done) => {
+    ipfs.dag.put(obj, (err, cid) => {
+      expect(err).to.not.exist()
+      ipfs.dag.get(cid, (err, data) => {
+        expect(err).to.not.exist()
+        expect(data.value).deep.equal(obj)
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
Hi!

I was trying to solve #790 but I decided to stop here because I'm not sure if this is the right path and I decide to ask you what to do next.

Initially, I searched in the [HTTP-API](https://ipfs.io/docs/api/#apiv0dagget) for an endpoint "/dag/tree", but I did not find it. I also ran the go daemon and made some tests but it seems that the endpoint is not there yet. According to the [documentation](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/DAG.md) the method `dag.tree` is only implemented in js-ipfs.

After that, I decided to write some code that is able to get the paths (no recursion yet) in order to get some exposure to the ipfs ecosystem and try to understand some of its components. I also added some tests for that.

Should I continue in this direction and add the logic for the recursive following of the links or the solution is finishing the HTTP-API?

Thank you! (:

