### PR TITLE
Fix for dag.get failing silently on missing multicodec

### DIFF
--- a/test/dag.spec.js
+++ b/test/dag.spec.js
@@ -1,0 +1,82 @@
+/* eslint-env mocha */
+/* eslint max-nested-callbacks: ["error", 8] */
+
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(dirtyChai)
+const series = require('async/series')
+const dagPB = require('ipld-dag-pb')
+const DAGNode = dagPB.DAGNode
+
+const IPFSApi = require('../src')
+const f = require('./utils/factory')
+
+let ipfsd
+let ipfs
+
+describe('.dag', function () {
+  this.timeout(20 * 1000)
+  before(function (done) {
+    series([
+      (cb) => f.spawn({ initOptions: { bits: 1024 } }, (err, _ipfsd) => {
+        expect(err).to.not.exist()
+        ipfsd = _ipfsd
+        ipfs = IPFSApi(_ipfsd.apiAddr)
+        cb()
+      })
+    ], done)
+  })
+
+  after((done) => {
+    if (!ipfsd) return done()
+    ipfsd.stop(done)
+  })
+
+  it('should be able to put and get a DAG node with format dag-pb', (done) => {
+    const data = Buffer.from('some data')
+    DAGNode.create(data, (err, node) => {
+      expect(err).to.not.exist()
+      ipfs.dag.put(node, {format: 'dag-pb', hashAlg: 'sha2-256'}, (err, cid) => {
+        expect(err).to.not.exist()
+        cid = cid.toV0()
+        expect(cid.codec).to.equal('dag-pb')
+        cid = cid.toBaseEncodedString('base58btc')
+        // expect(cid).to.equal('bafybeig3t3eugdchignsgkou3ly2mmy4ic4gtfor7inftnqn3yq4ws3a5u')
+        expect(cid).to.equal('Qmd7xRhW5f29QuBFtqu3oSD27iVy35NRB91XFjmKFhtgMr')
+        ipfs.dag.get(cid, (err, result) => {
+          expect(err).to.not.exist()
+          expect(result.value.data).to.deep.equal(data)
+          done()
+        })
+      })
+    })
+  })
+
+  it('should be able to put and get a DAG node with format dag-cbor', (done) => {
+    const cbor = {foo: 'dag-cbor-bar'}
+    ipfs.dag.put(cbor, {format: 'dag-cbor', hashAlg: 'sha2-256'}, (err, cid) => {
+      expect(err).to.not.exist()
+      expect(cid.codec).to.equal('dag-cbor')
+      cid = cid.toBaseEncodedString('base32')
+      expect(cid).to.equal('bafyreic6f672hnponukaacmk2mmt7vs324zkagvu4hcww6yba6kby25zce')
+      ipfs.dag.get(cid, (err, result) => {
+        expect(err).to.not.exist()
+        expect(result.value).to.deep.equal(cbor)
+        done()
+      })
+    })
+  })
+
+  it('should callback with error when missing DAG resolver for raw multicodec', (done) => {
+    // CIDv1 with multicodec = raw
+    const cid = 'bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy'
+    ipfs.dag.get(cid, (err, result) => {
+      expect(result).to.not.exist()
+      expect(err.message).to.equal('ipfs-api is missing DAG resolver for "raw" multicodec')
+      done()
+    })
+  })
+})


### PR DESCRIPTION
Right now `ipfs.dag.get` fails silently for CIDs with codecs different than `dag-cbor` or `dag-pb`.
To reproduce, try `dag.get` for  `raw` one at  `bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy`.

This PR fixes the bug by returning error when codec resolver is missing. 

Notes:
- Problem occurs only in js-ipfs-api, js-ipfs already delegates resolvers to ipld which has proper error handling  [here](https://github.com/ipld/js-ipld/blob/19498948477af8e33018b7472e76f02d4df926f6/src/index.js#L163).
- Added regression tests for `dag.put+get`, not sure if it is the right place tho. Any feedback would be appreciated.
- Not sure what is the long term plan for resolvers,  I assume endgame will be https://github.com/ipfs/js-ipfs-api/pull/755 ?