### PR TITLE
test: allow for easier mocking of requests

### DIFF
--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const httpRequest = require('http').request
-const httpsRequest = require('https').request
+const http = require('http')
+const https = require('https')
 
 module.exports = (protocol) => {
   if (protocol.indexOf('https') === 0) {
-    return httpsRequest
+    return https.request
   }
 
-  return httpRequest
+  return http.request
 }


### PR DESCRIPTION
The way `http.request` is currently being included makes it a huge pain to mock the api requests with something like `nock`, since the request function cannot be stubbed the way it's being included.

This PR changes the way .request is being included, to allow for easier mocking.

I am using this change locally with nock to test some upcoming module additions to libp2p.