### PR TITLE
Support adding files using filestore

### DIFF
--- a/src/utils/send-files-stream.js
+++ b/src/utils/send-files-stream.js
@@ -22,6 +22,10 @@ function headers (file) {
     header['Content-Type'] = 'application/octet-stream'
   }
 
+  if (file.abspath) {
+    header.Abspath = file.abspath
+  }
+
   return header
 }
 


### PR DESCRIPTION

Hi,
Here is a small change to support adding files using the filestore in go-ipfs via the HTTP API. 
As described in #562, In order to use the filestore, an `Abspath` header must be specified which indicates the full path of the file in the local file system. This change provides a way to specify this header by using client code of the form:

```
  const filesAdded = await ipfs.files.add(
    {
      path: 'filename',
      abspath: '/full/path/to/filename',
      content: fs.createReadStream('/full/path/to/filename')
    },
    {
      nocopy: true,
    }
  )
```
Based on my testing, when using the updated code, and specifying the `abspath` and `nocopy` options, the go-ipfs daemon then uses the filestore for the added file.

I'm not sure if the best approach but wanted to create the pull request for consideration. I'm happy to update to an alternative approach if there is a better way. I think an update would also need to be done to the IPFS API spec but I can later do that if it's thought this approach has merit.

Thanks,
Simon
