### PR TITLE
small fix to bundle-browserify for recent js-ipfs-api

### DIFF
--- a/examples/bundle-browserify/index.js
+++ b/examples/bundle-browserify/index.js
@@ -6,7 +6,7 @@ var ipfs = IPFS()
 
 function store () {
   var toStore = document.getElementById('source').value
-  ipfs.add(Buffer.from(toStore), function (err, res) {
+  ipfs.files.add(Buffer.from(toStore), function (err, res) {
     if (err || !res) {
       return console.error('ipfs add error', err, res)
     }
@@ -21,8 +21,7 @@ function store () {
 }
 
 function display (hash) {
-  // buffer: true results in the returned result being a buffer rather than a stream
-  ipfs.cat(hash, {buffer: true}, function (err, res) {
+  ipfs.files.cat(hash, function (err, res) {
     if (err || !res) {
       return console.error('ipfs cat error', err, res)
     }

--- a/examples/bundle-browserify/package.json
+++ b/examples/bundle-browserify/package.json
@@ -11,9 +11,8 @@
   "license": "MIT",
   "devDependencies": {
     "browserify": "^13.1.1",
-    "ipfs-api": "^11.1.0",
+    "ipfs-api": "^24.0.0",
     "http-server": "~0.9.0"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Change API name and ipfs-api version to make the example work with newer js-ipfs-api versions.

Because ipfs.files.cat expects `stream` for response in recent versions, `{buffer: true}` option cause a crash (stream.pipe not defined).