### PR TITLE
fix: >150mb bodies no longer crashing Chromium

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "pump": "^3.0.0",
     "qs": "^6.5.2",
     "readable-stream": "^2.3.6",
-    "stream-http": "^2.8.3",
+    "stream-http": "^3.0.0",
     "stream-to-pull-stream": "^1.7.2",
     "streamifier": "~0.1.1",
     "tar-stream": "^1.6.1"


### PR DESCRIPTION
Switching ASAP to the latest version of `stream-http` with the fix by @hugomrdias \o/

Context: https://github.com/jhiesey/stream-http/pull/93
Closes #654 cc https://github.com/ipfs/in-web-browsers/issues/115