### PR TITLE
chore: remove ipld formats re-export

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -1,8 +1,6 @@
 'use strict'
 
 const CID = require('cids')
-const dagCBOR = require('ipld-dag-cbor')
-const dagPB = require('ipld-dag-pb')
 const multiaddr = require('multiaddr')
 const multibase = require('multibase')
 const multihash = require('multihashes')
@@ -12,8 +10,6 @@ const PeerInfo = require('peer-info')
 module.exports = () => ({
   Buffer: Buffer,
   CID: CID,
-  dagPB: dagPB,
-  dagCBOR: dagCBOR,
   multiaddr: multiaddr,
   multibase: multibase,
   multihash: multihash,

--- a/test/types.spec.js
+++ b/test/types.spec.js
@@ -3,8 +3,6 @@
 
 const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
-const dagCBOR = require('ipld-dag-cbor')
-const dagPB = require('ipld-dag-pb')
 const multiaddr = require('multiaddr')
 const multibase = require('multibase')
 const multihash = require('multihashes')
@@ -47,9 +45,7 @@ describe('.types', function () {
       multiaddr: multiaddr,
       multibase: multibase,
       multihash: multihash,
-      CID: CID,
-      dagPB: dagPB,
-      dagCBOR: dagCBOR
+      CID: CID
     })
   })
 })


### PR DESCRIPTION
Prior to this change the `ipld-dag-cbor` and `ipld-dag-pb` modules
are re-exported so that can be accessed within the Browser bundle.
Those modules normally don't need to be used directly, they are
kind of implementation details of IPLD. Hence remove them.

BREAKING CHANGE: remove `types.dagCBOR` and `dag.dagPB` from public API