### PR TITLE
fix: pin.ls ignored opts when hash was present

### DIFF
--- a/src/pin/ls.js
+++ b/src/pin/ls.js
@@ -12,14 +12,12 @@ module.exports = (send) => {
     }
     if (typeof opts === 'function') {
       callback = opts
+      opts = null
     }
     if (hash && hash.type) {
       opts = hash
       hash = null
-    } else {
-      opts = null
     }
-
     send({
       path: 'pin/ls',
       args: hash,


### PR DESCRIPTION
`ipfs.pin.ls` may get really slow for mid-large repos, especially when called without executing with `opts = {type: recursive}`. 

Unfortunately passing `opts` does not work right now: it is set to null if `hash` is also present.

[`interface-ipfs-core`](https://github.com/ipfs/interface-ipfs-core/blob/master/js/src/pin/ls.js) does not include proper tests for scenario when both `hash` and `opts` params are present, so it was not detected until I tried to use it in ipfs-companion (https://github.com/ipfs-shipyard/ipfs-companion/issues/360#issuecomment-427525801)

This PR fixes the bug by restoring passing of `opts`.

I add missing test cases to [`interface-ipfs-core/js/src/pin/ls.js`](https://github.com/ipfs/interface-ipfs-core/blob/master/js/src/pin/ls.js) in https://github.com/ipfs/interface-ipfs-core/pull/375