### PR TITLE
Fix log.tail by calling add after listening for events

### DIFF
--- a/test/log.spec.js
+++ b/test/log.spec.js
@@ -31,11 +31,16 @@ describe('.log', function () {
   })
 
   it('.log.tail', (done) => {
+    let i = setInterval(() => {
+      ipfs.files.add(Buffer.from('just adding some data to generate logs'))
+    }, 1000)
+
     const req = ipfs.log.tail((err, res) => {
       expect(err).to.not.exist()
       expect(req).to.exist()
 
       res.once('data', (obj) => {
+        clearInterval(i)
         expect(obj).to.be.an('object')
         done()
       })


### PR DESCRIPTION
This got broken in go-ipfs 0.4.18, I have no idea why it worked before..