### PR TITLE
fix: also retry with misnamed format "dag-cbor" as "cbor"

### DIFF
--- a/src/block/put.js
+++ b/src/block/put.js
@@ -55,10 +55,10 @@ module.exports = (send) => {
 
     sendOneFile(block.data, { qs }, (err, result) => {
       if (err) {
-        // Retry with "protobuf" format for go-ipfs
+        // Retry with "protobuf"/"cbor" format for go-ipfs
         // TODO: remove when https://github.com/ipfs/go-cid/issues/75 resolved
-        if (qs.format === 'dag-pb') {
-          qs.format = 'protobuf'
+        if (qs.format === 'dag-pb' || qs.format === 'dag-cbor') {
+          qs.format = qs.format === 'dag-pb' ? 'protobuf' : 'cbor'
           return sendOneFile(block.data, { qs }, (err, result) => {
             if (err) return callback(err)
             callback(null, new Block(block.data, new CID(result.Key)))


### PR DESCRIPTION
Prevents error unrecognized format: 'dag-cbor'