### PR TITLE
fix: updates ipld-dag-pb dep to version without .cid properties

### DIFF
--- a/examples/bundle-browserify/package.json
+++ b/examples/bundle-browserify/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "browserify": "^13.1.1",
-    "ipfs-api": "^24.0.0",
+    "ipfs-api": "../../",
     "http-server": "~0.9.0"
   },
   "dependencies": {}

--- a/examples/bundle-webpack/package.json
+++ b/examples/bundle-webpack/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "babel-core": "^5.4.7",
     "babel-loader": "^5.1.2",
-    "ipfs-api": "^11.1.0",
+    "ipfs-api": "../../",
     "json-loader": "~0.5.3",
     "react": "~0.13.0",
     "react-hot-loader": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ipfs-block": "~0.8.0",
     "ipfs-unixfs": "~0.1.16",
     "ipld-dag-cbor": "~0.13.0",
-    "ipld-dag-pb": "~0.14.11",
+    "ipld-dag-pb": "~0.15.0",
     "is-ipfs": "~0.4.7",
     "is-pull-stream": "0.0.0",
     "is-stream": "^1.1.0",
@@ -85,7 +85,7 @@
     "eslint-plugin-react": "^7.11.1",
     "go-ipfs-dep": "~0.4.18",
     "gulp": "^3.9.1",
-    "interface-ipfs-core": "~0.84.3",
+    "interface-ipfs-core": "~0.85.0",
     "ipfsd-ctl": "~0.40.0",
     "pull-stream": "^3.6.9",
     "stream-equal": "^1.1.1"

--- a/src/object/addLink.js
+++ b/src/object/addLink.js
@@ -26,7 +26,7 @@ module.exports = (send) => {
       args: [
         multihash,
         dLink.name,
-        cleanMultihash(dLink.multihash)
+        cleanMultihash(dLink.cid.buffer)
       ]
     }, (err, result) => {
       if (err) {

--- a/src/object/new.js
+++ b/src/object/new.js
@@ -35,10 +35,6 @@ module.exports = (send) => {
           return callback(err)
         }
 
-        if (node.toJSON().multihash !== result.Hash) {
-          return callback(new Error('multihashes do not match'))
-        }
-
         callback(null, node)
       })
     })

--- a/src/utils/clean-multihash.js
+++ b/src/utils/clean-multihash.js
@@ -1,11 +1,15 @@
 'use strict'
 
 const bs58 = require('bs58')
+const CID = require('cids')
 const isIPFS = require('is-ipfs')
 
 module.exports = function (multihash) {
   if (Buffer.isBuffer(multihash)) {
     multihash = bs58.encode(multihash)
+  }
+  if (CID.isCID(multihash)) {
+    multihash = multihash.toBaseEncodedString()
   }
   if (typeof multihash !== 'string') {
     throw new Error('unexpected multihash type: ' + typeof multihash)


### PR DESCRIPTION
Follows on from https://github.com/ipld/js-ipld-dag-pb/pull/99 and updates this module to not rely on DAGNodes having knowledge of their CIDs.